### PR TITLE
improve consistency of the code

### DIFF
--- a/module/accelerometer/README.md
+++ b/module/accelerometer/README.md
@@ -1,5 +1,4 @@
-Accelerometer Module
-====================
+# Accelerometer Module
 
 The goal of this module is to read the OpenBCI accelerometer channels from the FieldTrip bufferwrite them as a continuous control value to the REDIS buffer.
 

--- a/module/accelerometer/accelerometer.py
+++ b/module/accelerometer/accelerometer.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 import ConfigParser
+import argparse
+import mne
+import numpy
 import os
 import redis
 import sys
-import numpy
-import mne
 import time
-import argparse
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -19,8 +19,8 @@ installed_folder = os.path.split(basis)[0]
 
 # eegsynth/lib contains shared modules
 sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
-import FieldTrip
 import EEGsynth
+import FieldTrip
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")

--- a/module/avmixer/README.md
+++ b/module/avmixer/README.md
@@ -1,4 +1,4 @@
-# AVmixer module
+# AVmixer Module
 
 The purpose of this module is to provide an interface to the [AVmixer software](https://neuromixer.com/products/avmixer).
 

--- a/module/avmixer/avmixer.py
+++ b/module/avmixer/avmixer.py
@@ -1,13 +1,32 @@
 #!/usr/bin/env python
 
-import mido
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import mido
+import os
 import redis
+import sys
 import threading
 import time
-import sys
-import os
-import argparse
+
+if hasattr(sys, 'frozen'):
+    basis = sys.executable
+elif sys.argv[0]!='':
+    basis = sys.argv[0]
+else:
+    basis = './'
+installed_folder = os.path.split(basis)[0]
+
+# eegsynth/lib contains shared modules
+sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
+import EEGsynth
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
+args = parser.parse_args()
+
+config = ConfigParser.ConfigParser()
+config.read(args.inifile)
 
 # the settings dialog distinguishes three colors for sliders/knobs, buttons and switches
 slider_name = ['mixer/mixer1_mode', 'mixer/mixer1_fader', 'mixer/mixer2_mode', 'mixer/mixer2_fader', 'mixer/fade_to_black', 'color_fx/saturation', 'color_fx/hue1', 'color_fx/black1', 'color_fx/hue2', 'color_fx/black2', 'transform_fx/tile_mode', 'transform_fx/rotate', 'transform_fx/zoom', 'transform_fx/move_x', 'transform_fx/move_y', 'transform_fx/center_x', 'transform_fx/center_y', 'transform_fx/skew_x', 'transform_fx/skew_y', 'freeframe_fx1/pad1_x', 'freeframe_fx1/pad1_y', 'freeframe_fx1/pad2_x', 'freeframe_fx1/pad2_y', 'freeframe_fx1/pad3_x', 'freeframe_fx1/pad4_y', 'freeframe_fx2/pad1_x', 'freeframe_fx2/pad1_y', 'freeframe_fx2/pad2_x', 'freeframe_fx2/pad2_y', 'freeframe_fx2/pad3_x', 'freeframe_fx2/pad4_y', 'channelA/playback_speed', 'channelA/scrub_timeline', 'channelB/playback_speed', 'channelB/scrub_timeline', 'channelC/playback_speed', 'channelC/scrub_timeline']
@@ -30,25 +49,6 @@ control_name = slider_name
 control_code = slider_code
 note_name = button_name + switch_name
 note_code = button_code + switch_code
-
-if hasattr(sys, 'frozen'):
-    basis = sys.executable
-elif sys.argv[0]!='':
-    basis = sys.argv[0]
-else:
-    basis = './'
-installed_folder = os.path.split(basis)[0]
-
-# eegsynth/lib contains shared modules
-sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
-import EEGsynth
-
-parser = argparse.ArgumentParser()
-parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
-args = parser.parse_args()
-
-config = ConfigParser.ConfigParser()
-config.read(args.inifile)
 
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')

--- a/module/brain/README.md
+++ b/module/brain/README.md
@@ -1,5 +1,4 @@
-EEG processing module
-=====================
+# EEG Processing Module
 
 The goal of this module is to read EEG data from the FieldTrip buffer, to Fourier transform it and compute power in specific frequency bands. The power in each frequency band in each channel is written as control values to the REDIS buffer.
 

--- a/module/brain/brain.py
+++ b/module/brain/brain.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
 
-import time
+from nilearn import signal
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import math
+import multiprocessing
+import numpy as np
+import os
 import redis
 import sys
-import os
-import multiprocessing
 import threading
-import math
-import numpy as np
-from nilearn import signal
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -22,8 +22,8 @@ installed_folder = os.path.split(basis)[0]
 
 # eegsynth/lib contains shared modules
 sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
-import FieldTrip
 import EEGsynth
+import FieldTrip
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")

--- a/module/buffer/README.md
+++ b/module/buffer/README.md
@@ -1,8 +1,11 @@
-FieldTrip buffer module
-=======================
+# FieldTrip Buffer Module
 
-The goal of this module is to control the FieldTrip buffer. This buffer acts as a network transparent store for one or multiple channels of ExG data which are all sampled from the same acquisition device with the same sampling rate. The data is represented as a Nchannels*Ntimepoints matrix in a ring buffer. Furthermore, header information about the data stream is represented.
+The goal of this module is to start the FieldTrip buffer. This buffer acts as a network transparent store for one or multiple channels of ExG data which are all sampled from the same acquisition device with the same sampling rate. The data is represented as a Nchannels*Ntimepoints matrix in a ring buffer. Furthermore, header information about the data stream is represented.
 
 ## Requirements
 
 None.
+
+## Software Requirements
+
+The compiled binary can be downloaded with the eegsynth/bin/install script, or should be compiled in fieldtrip/realtime/src.

--- a/module/cogito/README.md
+++ b/module/cogito/README.md
@@ -1,5 +1,4 @@
-Cogito module
-=============
+# Cogito Module
 
 The purpose of this module is to convert an EEG buffer (channel x samples) into a single channel buffer, which can be played as audio in real time thanks to the ft2audio program.
 

--- a/module/cogito/cogito.py
+++ b/module/cogito/cogito.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-import sys
-import os
-import time
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
-import numpy as np
-import pandas as pd
 from copy import copy
+import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
 import argparse
+import numpy as np
+import os
+import pandas as pd
+import sys
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/endorphines/README.md
+++ b/module/endorphines/README.md
@@ -1,5 +1,4 @@
-Endorphines
-===========
+# Endorphines Module
 
 The purpose of this module is to send control values from REDIS to the Endorphin.es Shuttle Control. The Shuttle Control is a MIDI to CV/Gate converter with 16 channels that can be controlled from -5 to +5 Volt.
 

--- a/module/endorphines/endorphines.py
+++ b/module/endorphines/endorphines.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-import time
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import mido
+import os
 import redis
 import sys
-import os
 import threading
-import mido
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/eyeblink/README.md
+++ b/module/eyeblink/README.md
@@ -1,5 +1,4 @@
-EOG processing module
-=====================
+# EOG Processing Module
 
 The goal of this module is to read EOG data from the FieldTrip buffer, to detect eye blinks and saccades and to send a trigger (gate) to the REDIS buffer.
 

--- a/module/eyeblink/eyeblink.py
+++ b/module/eyeblink/eyeblink.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
-import time
+from nilearn import signal
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import numpy as np
+import os
 import redis
 import sys
-import os
 import threading
-import numpy as np
-from nilearn import signal
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/generatesignal/README.md
+++ b/module/generatesignal/README.md
@@ -1,5 +1,4 @@
-Generate Signal Module
-======================
+# Generate Signal Module
 
 This module generates a simulated ExG signal that consists of a sinewave
 plus additive noise. The frequency, amplitude and noise can be changed

--- a/module/generatesignal/generatesignal.py
+++ b/module/generatesignal/generatesignal.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import sys
-import os
-import time
-import redis
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
-import numpy as np
 import argparse
+import numpy as np
+import os
+import redis
+import sys
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/heartrate/README.md
+++ b/module/heartrate/README.md
@@ -1,5 +1,4 @@
-Heart Rate Module
-=================
+# Heart Rate Module
 
 The goal of this module is to read an ECG channel from the FieldTrip buffer and to detect the heart rate. The heart rate is written as a continuous control value to the REDIS buffer (expressed in beats per minute).
 

--- a/module/heartrate/heartrate.py
+++ b/module/heartrate/heartrate.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 import ConfigParser
+import argparse
+import mne
+import numpy as np
 import os
 import redis
 import sys
-import numpy as np
-import mne
 import time
-import argparse
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/inputmidi/README.md
+++ b/module/inputmidi/README.md
@@ -1,5 +1,4 @@
-Input MIDI module
-====================
+# Input MIDI Module
 
 The purpose of this module is to process incoming commands from a generic MIDI device or from MIDI software running on the same computer.
 

--- a/module/inputmidi/inputmidi.py
+++ b/module/inputmidi/inputmidi.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import mido
-import time
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import mido
+import os
 import redis
 import sys
-import os
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -15,6 +15,10 @@ elif sys.argv[0]!='':
 else:
     basis = './'
 installed_folder = os.path.split(basis)[0]
+
+# eegsynth/lib contains shared modules
+sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
+import EEGsynth
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")

--- a/module/inputosc/README.md
+++ b/module/inputosc/README.md
@@ -1,5 +1,4 @@
-Input OSC module
-================
+# Input OSC Module
 
 The purpose of this module is to process input messages that are received from Open Sound Control (OSC). The values of the OSC messages are send as control signals to the REDIS buffer. The button press and release events are sent as triggers to the REDIS buffer.
 

--- a/module/inputosc/inputosc.py
+++ b/module/inputosc/inputosc.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
-import sys
-import os
-import socket
-import time
-import threading
-import redis
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
 import OSC          # see https://trac.v2.nl/wiki/pyOSC
 import argparse
+import os
+import redis
+import socket
+import sys
+import threading
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/keyboard/README.md
+++ b/module/keyboard/README.md
@@ -1,8 +1,6 @@
-Keyboard module
-===============
+# Keyboard Module
 
 The purpose of this module is to receive and send input MIDI commands from/to a keyboard such as a digital piano. This implementation has been tested with a [Yamaha P95](http://usa.yamaha.com/products/musical-instruments/keyboards/digitalpianos/p_series/p-95_color_variation/).
-
 
 The MIDI commands received from the piano corresponding to keys that are pressed are translated into a single control value representing the pitch. The force with which the key is pressed is send as trigger for each of the keys. Both the control value and the trigger are send to the REDIS buffer. You can filter on key press and release events.
 

--- a/module/keyboard/keyboard.py
+++ b/module/keyboard/keyboard.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python
 
-import mido
-import time
 import ConfigParser # this is version 2.x specific, on version 3.x it is called 'configparser' and has a different API
-import redis
-import threading
-import sys
-import os
 import argparse
-
-# the list of MIDI commands is specific to the implementation for a full-scale keyboard
-# see https://newt.phys.unsw.edu.au/jw/notes.html
-note_name = ['C0', 'Db0', 'D0', 'Eb0', 'E0', 'F0', 'Gb0', 'G0', 'Ab0', 'A0', 'Bb0', 'B0', 'C1', 'Db1', 'D1', 'Eb1', 'E1', 'F1', 'Gb1', 'G1', 'Ab1', 'A1', 'Bb1', 'B1', 'C2', 'Db2', 'D2', 'Eb2', 'E2', 'F2', 'Gb2', 'G2', 'Ab2', 'A2', 'Bb2', 'B2', 'C3', 'Db3', 'D3', 'Eb3', 'E3', 'F3', 'Gb3', 'G3', 'Ab3', 'A3', 'Bb3', 'B3', 'C4', 'Db4', 'D4', 'Eb4', 'E4', 'F4', 'Gb4', 'G4', 'Ab4', 'A4', 'Bb4', 'B4', 'C5', 'Db5', 'D5', 'Eb5', 'E5', 'F5', 'Gb5', 'G5', 'Ab5', 'A5', 'Bb5', 'B5', 'C6', 'Db6', 'D6', 'Eb6', 'E6', 'F6', 'Gb6', 'G6', 'Ab6', 'A6', 'Bb6', 'B6', 'C7', 'Db7', 'D7', 'Eb7', 'E7', 'F7', 'Gb7', 'G7', 'Ab7', 'A7', 'Bb7', 'B7', 'C8', 'Db8', 'D8', 'Eb8', 'E8', 'F8', 'Gb8', 'G8', 'Ab8', 'A8', 'Bb8', 'B8', 'C9', 'Db9', 'D9', 'Eb9', 'E9', 'F9', 'Gb9', 'G9', 'Ab9', 'A9', 'Bb9', 'B9', 'C10', 'Db10', 'D10', 'Eb10', 'E10', 'F10', 'Gb10', 'G10', 'Ab10', 'A10', 'Bb10', 'B10']
-note_code = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
+import mido
+import os
+import redis
+import sys
+import threading
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -25,6 +20,11 @@ installed_folder = os.path.split(basis)[0]
 # eegsynth/lib contains shared modules
 sys.path.insert(0,os.path.join(installed_folder,'../../lib'))
 import EEGsynth
+
+# the list of MIDI commands is specific to the implementation for a full-scale keyboard
+# see https://newt.phys.unsw.edu.au/jw/notes.html
+note_name = ['C0', 'Db0', 'D0', 'Eb0', 'E0', 'F0', 'Gb0', 'G0', 'Ab0', 'A0', 'Bb0', 'B0', 'C1', 'Db1', 'D1', 'Eb1', 'E1', 'F1', 'Gb1', 'G1', 'Ab1', 'A1', 'Bb1', 'B1', 'C2', 'Db2', 'D2', 'Eb2', 'E2', 'F2', 'Gb2', 'G2', 'Ab2', 'A2', 'Bb2', 'B2', 'C3', 'Db3', 'D3', 'Eb3', 'E3', 'F3', 'Gb3', 'G3', 'Ab3', 'A3', 'Bb3', 'B3', 'C4', 'Db4', 'D4', 'Eb4', 'E4', 'F4', 'Gb4', 'G4', 'Ab4', 'A4', 'Bb4', 'B4', 'C5', 'Db5', 'D5', 'Eb5', 'E5', 'F5', 'Gb5', 'G5', 'Ab5', 'A5', 'Bb5', 'B5', 'C6', 'Db6', 'D6', 'Eb6', 'E6', 'F6', 'Gb6', 'G6', 'Ab6', 'A6', 'Bb6', 'B6', 'C7', 'Db7', 'D7', 'Eb7', 'E7', 'F7', 'Gb7', 'G7', 'Ab7', 'A7', 'Bb7', 'B7', 'C8', 'Db8', 'D8', 'Eb8', 'E8', 'F8', 'Gb8', 'G8', 'Ab8', 'A8', 'Bb8', 'B8', 'C9', 'Db9', 'D9', 'Eb9', 'E9', 'F9', 'Gb9', 'G9', 'Ab9', 'A9', 'Bb9', 'B9', 'C10', 'Db10', 'D10', 'Eb10', 'E10', 'F10', 'Gb10', 'G10', 'Ab10', 'A10', 'Bb10', 'B10']
+note_code = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")

--- a/module/launchcontrol/README.md
+++ b/module/launchcontrol/README.md
@@ -1,5 +1,4 @@
-Launch Control module
-=====================
+# Launch Control Module
 
 The purpose of this module is to process input MIDI commands from a Novation LaunchControl or LaunchControlXL digital control surface. The values of the sliders and knobs are sent as control signals to the REDIS buffer. The button press and release events are sent as triggers to the REDIS buffer.
 

--- a/module/launchcontrol/launchcontrol.py
+++ b/module/launchcontrol/launchcontrol.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import mido
-import time
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import mido
+import os
 import redis
 import sys
-import os
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -15,6 +15,10 @@ elif sys.argv[0]!='':
 else:
     basis = './'
 installed_folder = os.path.split(basis)[0]
+
+# eegsynth/lib contains shared modules
+sys.path.insert(0,os.path.join(installed_folder,'../../lib'))
+import EEGsynth
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")

--- a/module/launchpad/README.md
+++ b/module/launchpad/README.md
@@ -1,5 +1,4 @@
-Launchpad MK2  module
-=================
+# Launchpad Module
 
 The purpose of this module is to process input MIDI commands from a Novation Launchpad digital control surface. The button press and release events are sent as triggers to the REDIS buffer.
 

--- a/module/launchpad/launchpad.py
+++ b/module/launchpad/launchpad.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import mido
-import time
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import mido
+import os
 import redis
 import sys
-import os
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -15,6 +15,10 @@ elif sys.argv[0]!='':
 else:
     basis = './'
 installed_folder = os.path.split(basis)[0]
+
+# eegsynth/lib contains shared modules
+sys.path.insert(0,os.path.join(installed_folder,'../../lib'))
+import EEGsynth
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")

--- a/module/muscle/README.md
+++ b/module/muscle/README.md
@@ -1,5 +1,4 @@
-EMG processing module
-=====================
+# Muscle Processing Module
 
 The goal of this module is to read one or multiple channels of bipolar EMG data from the FieldTrip buffer, to compute a sliding window RMS amplitude, to apply offset, scaling, clipping and to output the normalized control signal for each channel to the REDIS buffer.
 

--- a/module/muscle/muscle.py
+++ b/module/muscle/muscle.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
 
-import time
+from nilearn import signal
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import math
+import multiprocessing
+import numpy as np
+import os
 import redis
 import sys
-import os
-import multiprocessing
 import threading
-import math
-import numpy as np
-from nilearn import signal
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -22,6 +22,7 @@ installed_folder = os.path.split(basis)[0]
 
 # eegsynth/lib contains shared modules
 sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
+import EEGsynth
 import FieldTrip
 
 parser = argparse.ArgumentParser()

--- a/module/openbci2ft/README.md
+++ b/module/openbci2ft/README.md
@@ -1,5 +1,4 @@
-OpenBCI  module
-===============
+# OpenBCI Module
 
 The goal of this module is to read data from the OpenBCI board (over the Bluetooth RF interface) and to write this data to the FieldTrip buffer. At the start of data acquisition the FieldTrip buffer will be reset.
 

--- a/module/outputartnet/README.md
+++ b/module/outputartnet/README.md
@@ -1,5 +1,4 @@
-Output DMX512 module
-====================
+# Output DMX512 Module
 
 The purpose of this module is to send control values from REDIS over Art-Net to network-connected DMX512 devices.
 

--- a/module/outputartnet/outputartnet.py
+++ b/module/outputartnet/outputartnet.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import sys
-import os
-import time
-import redis
-import serial
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
 import argparse
+import os
+import redis
+import serial
+import sys
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/outputaudio/README.md
+++ b/module/outputaudio/README.md
@@ -1,0 +1,15 @@
+# Output Audio Module
+
+The purpose of this module is to send a signal from a FieldTrip buffer to the audio card, i.e. to play the signal to the attached speakers or headset.
+
+This module is based on a compiled applicatin that is implemented in C-code. The source code of the application itself is maintained in the FieldTrip project.
+
+## Requirements
+
+The FieldTrip buffer should be running and should receive one or two channels of data at at appropriate sampling rate (11025, 22050, or 44100 Hz).
+
+The computer running this module should have a supported audio system.
+
+## Software Requirements
+
+The compiled binary can be downloaded with the eegsynth/bin/install script, or should be compiled in fieldtrip/realtime/src.

--- a/module/outputcvgate/README.md
+++ b/module/outputcvgate/README.md
@@ -1,5 +1,4 @@
-Output CV/Gate module
-=====================
+# Output CV/Gate Module
 
 The goal of this module is to read control values from the REDIS buffer and writes a serial output command to the Arduino-based USB to CV/Gate converter.
 

--- a/module/outputcvgate/outputcvgate.py
+++ b/module/outputcvgate/outputcvgate.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import time
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import os
 import redis
 import serial
 import sys
-import os
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/outputdmx512/README.md
+++ b/module/outputdmx512/README.md
@@ -1,5 +1,4 @@
-Output DMX512 module
-====================
+# Output DMX512 Module
 
 The purpose of this module is to send control values from REDIS to DMX512 light systems using an Enntec DMX USB Pro (or compatible) converter.
 

--- a/module/outputdmx512/outputdmx512.py
+++ b/module/outputdmx512/outputdmx512.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import sys
-import os
-import time
-import redis
-import serial
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
 import argparse
+import os
+import redis
+import serial
+import sys
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/outputosc/README.md
+++ b/module/outputosc/README.md
@@ -1,5 +1,4 @@
-Output OSC module
-=================
+# Output OSC Module
 
 The purpose of this module is to send control values from REDIS to Open Sound Control (OSC).
 

--- a/module/outputosc/outputosc.py
+++ b/module/outputosc/outputosc.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import sys
-import os
-import time
-import redis
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
 import OSC          # see https://trac.v2.nl/wiki/pyOSC
 import argparse
+import os
+import redis
+import sys
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/playback/README.md
+++ b/module/playback/README.md
@@ -1,5 +1,4 @@
-Playback module
-===============
+# Playback Module
 
 The purpose of this module is to read EEG data from an EDF file and to play it back in real time to the FieldTrip buffer.
 

--- a/module/playback/playback.py
+++ b/module/playback/playback.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import time
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import numpy as np
+import os
 import redis
 import sys
-import os
-import numpy as np
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -18,8 +18,8 @@ installed_folder = os.path.split(basis)[0]
 
 # eegsynth/lib contains shared modules
 sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
-import FieldTrip
 import EEGsynth
+import FieldTrip
 import EDF
 
 parser = argparse.ArgumentParser()

--- a/module/playback/playback.py
+++ b/module/playback/playback.py
@@ -91,9 +91,10 @@ blocksize = int(config.getfloat('playback', 'blocksize')*H.fSample)
 begsample = 0
 endsample = blocksize-1
 block     = 0
-adjust    = 1
 
+print "STARTING STREAM"
 while True:
+
     if endsample>H.nSamples-1:
         if debug>0:
             print "End of file reached, jumping back to start"
@@ -117,27 +118,30 @@ while True:
         continue
 
     # measure the time that it takes
-    now = time.time()
+    start = time.time()
 
     if debug>1:
-        print "Playing section", block, 'from', begsample, 'to', endsample
+        print "Playing block", block, 'from', begsample, 'to', endsample
 
     D = np.ndarray(shape=(blocksize, H.nChannels), dtype=np.float32)
     for chanindx in range(H.nChannels):
         D[:,chanindx] = f.readSamples(chanindx, begsample, endsample)
 
+    # write the data to the output buffer
     ftc.putData(D)
-
-    # this approximates the real time streaming speed
-    desired = blocksize/(H.fSample*EEGsynth.getfloat('playback', 'speed', config, r))
-    # the adjust factor compensates for the time spent on reading and writing the data
-    time.sleep(adjust * desired);
 
     begsample += blocksize
     endsample += blocksize
     block += 1
 
-    elapsed = time.time() - now
-    # adjust the relative delay for the next iteration
-    # the adjustment factor should only change a little per iteration
-    adjust = 0.1 * desired/elapsed + 0.9 * adjust
+    # this is a short-term approach, estimating the sleep for every block
+    # this code is shared between generatesignal, playback and playbackctrl
+    desired = blocksize/(H.fSample*EEGsynth.getfloat('playback', 'speed', config, r))
+    elapsed = time.time()-start
+    naptime = desired - elapsed
+    if naptime>0:
+        # this approximates the real time streaming speed
+        time.sleep(naptime)
+
+    if debug>0:
+        print "played", blocksize, "samples in", (time.time()-start)*1000, "ms"

--- a/module/playbackctrl/README.md
+++ b/module/playbackctrl/README.md
@@ -1,5 +1,4 @@
-Control playback module
-=======================
+# Control Playback Module
 
 The purpose of this module is read control values from an EDF file and to play them back in real time to REDIS.
 

--- a/module/playbackctrl/playbackctrl.py
+++ b/module/playbackctrl/playbackctrl.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
-import time
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import datetime
+import numpy as np
+import os
 import redis
 import sys
-import os
-import numpy as np
-import datetime
 import time
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/playbackctrl/playbackctrl.py
+++ b/module/playbackctrl/playbackctrl.py
@@ -2,12 +2,10 @@
 
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
 import argparse
-import datetime
 import numpy as np
 import os
 import redis
 import sys
-import time
 import time
 
 if hasattr(sys, 'frozen'):
@@ -42,6 +40,9 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+if debug>0:
+    print "Reading data from", config.get('playback', 'file')
+
 f = EDF.EDFReader()
 f.open(config.get('playback', 'file'))
 
@@ -49,6 +50,13 @@ if debug>1:
     print "NSignals", f.getNSignals()
     print "SignalFreqs", f.getSignalFreqs()
     print "NSamples", f.getNSamples()
+    print "SignalTextLabels", f.getSignalTextLabels()
+
+for chanindx in range(f.getNSignals()):
+    if f.getSignalFreqs()[chanindx]!=f.getSignalFreqs()[0]:
+        raise IOError('unequal SignalFreqs')
+    if f.getNSamples()[chanindx]!=f.getNSamples()[0]:
+        raise IOError('unequal NSamples')
 
 channels = f.getSignalTextLabels()
 channelz = f.getSignalTextLabels()
@@ -64,33 +72,19 @@ for replace in config.items('replace'):
 for s,z in zip(channels, channelz):
     print "Writing channel", s, "as control value", z
 
-for chanindx in range(f.getNSignals()):
-    if f.getSignalFreqs()[chanindx]!=f.getSignalFreqs()[0]:
-        raise IOError('unequal SignalFreqs')
-    if f.getNSamples()[chanindx]!=f.getNSamples()[0]:
-        raise IOError('unequal NSamples')
-
-block     = 0
 blocksize = 1
 begsample = 0
-endsample = 0
-adjust    = 1
+endsample = blocksize-1
+block     = 0
 
-# this approximates the real time streaming speed
-desired = blocksize/(fSample*EEGsynth.getfloat('playback', 'speed', config, r))
-elapsed = desired
-naptime = 0.02
-
+print "STARTING STREAM"
 while True:
-
-    # measure the time that it takes
-    now = time.time()
 
     if endsample>nSamples-1:
         if debug>0:
             print "End of file reached, jumping back to start"
         begsample = 0
-        endsample = 0
+        endsample = blocksize-1
         block     = 0
         continue
 
@@ -98,7 +92,7 @@ while True:
         if debug>0:
             print "Rewind pressed, jumping back to start of file"
         begsample = 0
-        endsample = 0
+        endsample = blocksize-1
         block     = 0
         continue
 
@@ -108,8 +102,11 @@ while True:
         time.sleep(0.1);
         continue
 
+    # measure the time that it takes
+    start = time.time()
+
     if debug>1:
-        print "Playing control value", block
+        print "Playing control value", block, 'from', begsample, 'to', endsample
 
     dat = map(int, f.readBlock(block))
     r.mset(dict(zip(channelz,dat)))
@@ -118,19 +115,14 @@ while True:
     endsample += blocksize
     block += 1
 
-    # the adjust factor compensates for the time spent on reading and writing the data
-    naptime = (0.95 * naptime) + 0.05 * (naptime * (desired/elapsed))
-    if naptime < 0:
-        naptime = 0
+    # this is a short-term approach, estimating the sleep for every block
+    # this code is shared between generatesignal, playback and playbackctrl
+    desired = blocksize/(fSample*EEGsynth.getfloat('playback', 'speed', config, r))
+    elapsed = time.time()-start
+    naptime = desired - elapsed
+    if naptime>0:
+        # this approximates the real time streaming speed
+        time.sleep(naptime)
 
-    time.sleep(naptime)
-
-    elapsed = time.time() - now
-    # adjust the relative delay for the next iteration
-    # the adjustment factor should only change a little per iteration
-    #adjust = (0.1 * desired/elapsed + 0.9 * adjust)
-
-    if debug>1:
-        print "It took a total of", elapsed
-        print "Of which I slept", naptime
-        print "I was off by", (desired - elapsed)
+    if debug>0:
+        print "played", blocksize, "samples in", (time.time()-start)*1000, "ms"

--- a/module/plotsignal/README.md
+++ b/module/plotsignal/README.md
@@ -1,3 +1,7 @@
+# Signal Plotting Module
+
+The purpose of this module is to visualize the ExG signals in real time, together with their power spectra.
+
 ## Software Requirements
 
 Python 2.7.x

--- a/module/plotsignal/plotsignal.py
+++ b/module/plotsignal/plotsignal.py
@@ -1,22 +1,43 @@
 #!/usr/bin/env python
 
-import sys
-import os
-import time
-import redis
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
-import numpy as np
-import matplotlib.pyplot as plt
-import scipy.signal
-import scipy.fftpack
 from pyqtgraph.Qt import QtGui, QtCore
-import numpy as np
-import pyqtgraph as pg
-from scipy.signal import butter, lfilter
 from scipy.interpolate import interp1d
+from scipy.signal import butter, lfilter
+import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
 import argparse
+import matplotlib.pyplot as plt
+import numpy as np
+import numpy as np
+import os
+import pyqtgraph as pg
+import redis
+import scipy.fftpack
+import scipy.signal
+import sys
+import time
 
-# basis = '/Users/stephen/eegsynth/module/plotsignal/'
+if hasattr(sys, 'frozen'):
+    basis = sys.executable
+elif sys.argv[0]!='':
+    basis = sys.argv[0]
+else:
+    basis = './'
+installed_folder = os.path.split(basis)[0]
+
+# eegsynth/lib contains shared modules
+sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
+import EEGsynth
+import FieldTrip
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
+args = parser.parse_args()
+
+config = ConfigParser.ConfigParser()
+config.read(args.inifile)
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 def butter_bandpass(lowcut, highcut, fs, order=9):
     nyq = 0.5 * fs
@@ -40,33 +61,6 @@ def butter_lowpass_filter(data, lowcut, fs, order=9):
     b, a = butter_lowpass(lowcut, fs, order=order)
     y    = lfilter(b, a, data)
     return y
-
-if hasattr(sys, 'frozen'):
-    basis = sys.executable
-elif sys.argv[0]!='':
-    basis = sys.argv[0]
-else:
-    basis = '../../eegsynth'
-
-installed_folder = os.path.split(basis)[0]
-# installed_folder = '/home/stephen/eegsynth/module/plotsignal'
-
-# eegsynth/lib contains shared modules
-sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
-sys.path.insert(0,'../../lib/')
-
-import EEGsynth
-import FieldTrip
-
-parser = argparse.ArgumentParser()
-parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
-args = parser.parse_args()
-
-config = ConfigParser.ConfigParser()
-config.read(args.inifile)
-
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
 
 try:
     ftc_host = config.get('fieldtrip','hostname')

--- a/module/postprocessing/README.md
+++ b/module/postprocessing/README.md
@@ -1,5 +1,4 @@
-Post-processing module
-======================
+# Post-processing Module
 
 The purpose of this module is to do post-processing on specific control values in the redis buffer. You can specify mathematical equations on these values. The result of the equations is written back into the redis buffer.
 

--- a/module/postprocessing/postprocessing.py
+++ b/module/postprocessing/postprocessing.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-import sys
-import os
-import time
-import redis
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
-import numpy as np
 from numpy import log, log2, log10, exp, power, sqrt, mean, median, var, std
+import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
 import argparse
+import numpy as np
+import os
+import redis
+import sys
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -20,6 +20,7 @@ installed_folder = os.path.split(basis)[0]
 # eegsynth/lib contains shared modules
 sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
 import EEGsynth
+
 # these function names can be used in the equation that gets parsed
 from EEGsynth import compress, limit, rescale
 

--- a/module/preprocessing/README.md
+++ b/module/preprocessing/README.md
@@ -1,5 +1,4 @@
-Pre-processing module
-=====================
+# Pre-processing Module
 
 The purpose of this module is to do filtering and re-referencing on the
 ExG data that is recorded.  The input data is read from one FieldTrip

--- a/module/preprocessing/preprocessing.py
+++ b/module/preprocessing/preprocessing.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
 
-import sys
-import os
-import time
-import redis
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
 from copy import copy
-import numpy as np
 from numpy.matlib import repmat
-from scipy.signal import firwin
 from scipy.ndimage import convolve1d
+from scipy.signal import firwin
+import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
 import argparse
+import numpy as np
+import os
+import redis
+import sys
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/quantizer/README.md
+++ b/module/quantizer/README.md
@@ -1,5 +1,4 @@
-Quantizer module
-================
+# Quantizer Module
 
 The purpose of this module is to quantize control values from the redis buffer, i.e. round them to the nearest value of a pre-specified list. The output values are subsequently looked up in matching lists, and can be shifted with a certain amount (e.g. octave, fifth) or can represent a non-linear transformation.
 

--- a/module/quantizer/quantizer.py
+++ b/module/quantizer/quantizer.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-import sys
-import os
-import time
-import redis
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
-import numpy as np
 import argparse
+import numpy as np
+import os
+import redis
+import sys
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/record/README.md
+++ b/module/record/README.md
@@ -1,5 +1,4 @@
-Recording module
-================
+# Recording Module
 
 The purpose of this module is to record EEG data from the FieldTrip buffet to an EDF file.
 

--- a/module/record/record.py
+++ b/module/record/record.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-import time
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import datetime
+import numpy as np
+import os
 import redis
 import sys
-import os
-import numpy as np
-import datetime
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -19,8 +19,8 @@ installed_folder = os.path.split(basis)[0]
 
 # eegsynth/lib contains shared modules
 sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
-import FieldTrip
 import EEGsynth
+import FieldTrip
 import EDF
 
 parser = argparse.ArgumentParser()

--- a/module/recordctrl/README.md
+++ b/module/recordctrl/README.md
@@ -1,5 +1,4 @@
-Control recording module
-========================
+# Control Recording Module
 
 The purpose of this module is to record control values from REDIS to an EDF file.
 

--- a/module/recordctrl/recordctrl.py
+++ b/module/recordctrl/recordctrl.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
-import time
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import datetime
+import numpy as np
+import os
 import redis
 import sys
-import os
-import numpy as np
-import datetime
 import time
-import argparse
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/redis/README.md
+++ b/module/redis/README.md
@@ -1,7 +1,6 @@
-Redis module
-============
+# Redis Module
 
-The purpose of this module is to allow communication between (most) other modules, which use put/get and pub/sub to send and receive messages. Compared to the patching of an analog synthesizer with cables, the REDIS module allows all other modules to be flexibly linked to each other.
+The purpose of this module is to start the REDIS key-value database database. This allows communication between (most) other modules, which use put/get and pub/sub to send and receive messages. Compared to the patching of an analog synthesizer with cables, the REDIS module allows all other modules to be flexibly linked to each other.
 
 This module should be started prior to all other modules.
 

--- a/module/sequencer/README.md
+++ b/module/sequencer/README.md
@@ -1,0 +1,12 @@
+# Sequencer Module
+
+The purpose of this module is to repeatedly play a pre-configured sequence of notes to the REDIS buffer. Using the synchronization module these notes can subsequently be sent to an external CV/Gate or MIDI device.
+
+## Requirements
+
+The REDIS buffer should be running.
+
+## Software Requirements
+
+Python 2.x
+Redis Python library

--- a/module/sequencer/sequencer.py
+++ b/module/sequencer/sequencer.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python
 
-import math
 import ConfigParser # this is version 2.x specific,on version 3.x it is called "configparser" and has a different API
-import redis
-import time
-import sys
-import os
 import argparse
+import math
+import os
+import redis
+import sys
+import time
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
-else:
+elif sys.argv[0]!='':
     basis = sys.argv[0]
+else:
+    basis = './'
 installed_folder = os.path.split(basis)[0]
 
 # eegsynth/lib contains shared modules

--- a/module/synchronization/README.md
+++ b/module/synchronization/README.md
@@ -1,5 +1,4 @@
-Synchronization Module
-======================
+# Synchronization Module
 
 The goal of this module is to use a continuous control value from the REDIS buffer for synchronization. The time between pulses scales linearly with the control value magnitude.
 

--- a/module/synchronization/synchronization.py
+++ b/module/synchronization/synchronization.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
-import redis
+import argparse
 import mido
+import numpy as np
+import os
+import redis
 import serial
+import sys
 import threading
 import time
-import sys
-import os
-import numpy as np
-import argparse
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable

--- a/module/synthesizer/README.md
+++ b/module/synthesizer/README.md
@@ -1,5 +1,4 @@
-LaunchControl module
-====================
+# LaunchControl Module
 
 The purpose of this module is to provide a simple virtual synthesizer using the computer audio output. This virtual synthesizer consists of a few standard modules.
 

--- a/module/synthesizer/synthesizer.py
+++ b/module/synthesizer/synthesizer.py
@@ -1,21 +1,25 @@
 #!/usr/bin/env python
 
-import math
-import pyaudio
 import ConfigParser # this is version 2.x specific,on version 3.x it is called "configparser" and has a different API
-import redis
+import argparse
+import math
 import multiprocessing
+import os
+import pyaudio
+import redis
+import sys
 import threading
 import time
-import sys
-import os
-import argparse
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
 else:
     basis = sys.argv[0]
 installed_folder = os.path.split(basis)[0]
+
+# eegsynth/lib contains shared modules
+sys.path.insert(0, os.path.join(installed_folder,'../../lib'))
+import EEGsynth
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")

--- a/module/volcabass/README.md
+++ b/module/volcabass/README.md
@@ -1,5 +1,4 @@
-Volca Bass module
-=================
+# Volca Bass Module
 
 The purpose of this module is to write control values as MIDI commands to the Korg Volca Bass.
 

--- a/module/volcabass/volcabass.py
+++ b/module/volcabass/volcabass.py
@@ -1,20 +1,13 @@
 #!/usr/bin/env python
 
-import mido
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import mido
+import os
 import redis
+import sys
 import threading
 import time
-import sys
-import os
-import argparse
-
-# the list of MIDI commands is the only aspect that is specific to the Volca Bass
-# see http://media.aadl.org/files/catalog_guides/1444141_chart.pdf
-control_name = ['slide_time', 'expression', 'octave', 'lfo_rate', 'lfo_int', 'vco_pitch1', 'vco_pitch2', 'vco_pitch3', 'attack', 'decay_release', 'cutoff_intensity', 'gate_time']
-control_code = [5, 11, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
-note_name = ['C0', 'Db0', 'D0', 'Eb0', 'E0', 'F0', 'Gb0', 'G0', 'Ab0', 'A0', 'Bb0', 'B0', 'C1', 'Db1', 'D1', 'Eb1', 'E1', 'F1', 'Gb1', 'G1', 'Ab1', 'A1', 'Bb1', 'B1', 'C2', 'Db2', 'D2', 'Eb2', 'E2', 'F2', 'Gb2', 'G2', 'Ab2', 'A2', 'Bb2', 'B2', 'C3', 'Db3', 'D3', 'Eb3', 'E3', 'F3', 'Gb3', 'G3', 'Ab3', 'A3', 'Bb3', 'B3', 'C4', 'Db4', 'D4', 'Eb4', 'E4', 'F4', 'Gb4', 'G4', 'Ab4', 'A4', 'Bb4', 'B4', 'C5', 'Db5', 'D5', 'Eb5', 'E5', 'F5', 'Gb5', 'G5', 'Ab5', 'A5', 'Bb5', 'B5', 'C6', 'Db6', 'D6', 'Eb6', 'E6', 'F6', 'Gb6', 'G6', 'Ab6', 'A6', 'Bb6', 'B6', 'C7', 'Db7', 'D7', 'Eb7', 'E7', 'F7', 'Gb7', 'G7', 'Ab7', 'A7', 'Bb7', 'B7', 'C8', 'Db8', 'D8', 'Eb8', 'E8', 'F8', 'Gb8', 'G8', 'Ab8', 'A8', 'Bb8', 'B8', 'C9', 'Db9', 'D9', 'Eb9', 'E9', 'F9', 'Gb9', 'G9', 'Ab9', 'A9', 'Bb9', 'B9', 'C10', 'Db10', 'D10', 'Eb10', 'E10', 'F10', 'Gb10', 'G10', 'Ab10', 'A10', 'Bb10', 'B10']
-note_code = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -37,6 +30,13 @@ config.read(args.inifile)
 
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
+
+# the list of MIDI commands is the only aspect that is specific to the Volca Bass
+# see http://media.aadl.org/files/catalog_guides/1444141_chart.pdf
+control_name = ['slide_time', 'expression', 'octave', 'lfo_rate', 'lfo_int', 'vco_pitch1', 'vco_pitch2', 'vco_pitch3', 'attack', 'decay_release', 'cutoff_intensity', 'gate_time']
+control_code = [5, 11, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
+note_name = ['C0', 'Db0', 'D0', 'Eb0', 'E0', 'F0', 'Gb0', 'G0', 'Ab0', 'A0', 'Bb0', 'B0', 'C1', 'Db1', 'D1', 'Eb1', 'E1', 'F1', 'Gb1', 'G1', 'Ab1', 'A1', 'Bb1', 'B1', 'C2', 'Db2', 'D2', 'Eb2', 'E2', 'F2', 'Gb2', 'G2', 'Ab2', 'A2', 'Bb2', 'B2', 'C3', 'Db3', 'D3', 'Eb3', 'E3', 'F3', 'Gb3', 'G3', 'Ab3', 'A3', 'Bb3', 'B3', 'C4', 'Db4', 'D4', 'Eb4', 'E4', 'F4', 'Gb4', 'G4', 'Ab4', 'A4', 'Bb4', 'B4', 'C5', 'Db5', 'D5', 'Eb5', 'E5', 'F5', 'Gb5', 'G5', 'Ab5', 'A5', 'Bb5', 'B5', 'C6', 'Db6', 'D6', 'Eb6', 'E6', 'F6', 'Gb6', 'G6', 'Ab6', 'A6', 'Bb6', 'B6', 'C7', 'Db7', 'D7', 'Eb7', 'E7', 'F7', 'Gb7', 'G7', 'Ab7', 'A7', 'Bb7', 'B7', 'C8', 'Db8', 'D8', 'Eb8', 'E8', 'F8', 'Gb8', 'G8', 'Ab8', 'A8', 'Bb8', 'B8', 'C9', 'Db9', 'D9', 'Eb9', 'E9', 'F9', 'Gb9', 'G9', 'Ab9', 'A9', 'Bb9', 'B9', 'C10', 'Db10', 'D10', 'Eb10', 'E10', 'F10', 'Gb10', 'G10', 'Ab10', 'A10', 'Bb10', 'B10']
+note_code = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)

--- a/module/volcabeats/README.md
+++ b/module/volcabeats/README.md
@@ -1,5 +1,4 @@
-Volca Bass module
-=================
+# Volca Beats Module
 
 The purpose of this module is to write control values and notes as MIDI commands to the Korg Volca Beats.
 

--- a/module/volcabeats/volcabeats.py
+++ b/module/volcabeats/volcabeats.py
@@ -1,20 +1,13 @@
 #!/usr/bin/env python
 
-import mido
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import mido
+import os
 import redis
+import sys
 import threading
 import time
-import sys
-import os
-import argparse
-
-# the list of MIDI commands is the only aspect that is specific to the Volca Beats
-# see http://media.aadl.org/files/catalog_guides/1445131_chart.pdf
-control_name = ['kick_level', 'snare_level', 'lo_tom_level', 'hi_tom_level', 'closed_hat_level', 'open_hat_level', 'clap_level', 'claves_level', 'agogo_level', 'crash_level', 'clap_speed', 'claves_speed', 'agogo_speed', 'crash_speed', 'stutter_time', 'stutter_depth', 'tom_decay', 'closed_hat_decay', 'open_hat_decay', 'hat_gra    in']
-control_code = [40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]
-note_name = ['kick', 'snare', 'lo_tom', 'hi_tom', 'closed_hat', 'open_hat', 'clap']
-note_code = [36, 38, 43, 50, 42, 46, 39]
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -37,6 +30,13 @@ config.read(args.inifile)
 
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
+
+# the list of MIDI commands is the only aspect that is specific to the Volca Beats
+# see http://media.aadl.org/files/catalog_guides/1445131_chart.pdf
+control_name = ['kick_level', 'snare_level', 'lo_tom_level', 'hi_tom_level', 'closed_hat_level', 'open_hat_level', 'clap_level', 'claves_level', 'agogo_level', 'crash_level', 'clap_speed', 'claves_speed', 'agogo_speed', 'crash_speed', 'stutter_time', 'stutter_depth', 'tom_decay', 'closed_hat_decay', 'open_hat_decay', 'hat_gra    in']
+control_code = [40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]
+note_name = ['kick', 'snare', 'lo_tom', 'hi_tom', 'closed_hat', 'open_hat', 'clap']
+note_code = [36, 38, 43, 50, 42, 46, 39]
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)

--- a/module/volcakeys/README.md
+++ b/module/volcakeys/README.md
@@ -1,5 +1,4 @@
-Volca Keys module
-=================
+# Volca Keys Module
 
 The purpose of this module is to write control values and notes as MIDI commands to the Korg Volca Keys.
 

--- a/module/volcakeys/volcakeys.py
+++ b/module/volcakeys/volcakeys.py
@@ -1,20 +1,13 @@
 #!/usr/bin/env python
 
-import mido
 import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import argparse
+import mido
+import os
 import redis
+import sys
 import threading
 import time
-import sys
-import os
-import argparse
-
-# the list of MIDI commands is the only aspect that is specific to the Volca Keys
-# see http://media.aadl.org/files/catalog_guides/1444140_chart.pdf
-control_name = ['portamento', 'expression', 'voice', 'octave', 'detune', 'vco_eg_int', 'vcf_cutoff', 'vcf_eg_int', 'lfo_rate', 'lfo_pitch_int', 'lfo_cutoff_int', 'eg_attack', 'eg_decay_release', 'eg_sustain', 'delay_time', 'delay_feedback']
-control_code = [5, 11, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53]
-note_name = ['C0', 'Db0', 'D0', 'Eb0', 'E0', 'F0', 'Gb0', 'G0', 'Ab0', 'A0', 'Bb0', 'B0', 'C1', 'Db1', 'D1', 'Eb1', 'E1', 'F1', 'Gb1', 'G1', 'Ab1', 'A1', 'Bb1', 'B1', 'C2', 'Db2', 'D2', 'Eb2', 'E2', 'F2', 'Gb2', 'G2', 'Ab2', 'A2', 'Bb2', 'B2', 'C3', 'Db3', 'D3', 'Eb3', 'E3', 'F3', 'Gb3', 'G3', 'Ab3', 'A3', 'Bb3', 'B3', 'C4', 'Db4', 'D4', 'Eb4', 'E4', 'F4', 'Gb4', 'G4', 'Ab4', 'A4', 'Bb4', 'B4', 'C5', 'Db5', 'D5', 'Eb5', 'E5', 'F5', 'Gb5', 'G5', 'Ab5', 'A5', 'Bb5', 'B5', 'C6', 'Db6', 'D6', 'Eb6', 'E6', 'F6', 'Gb6', 'G6', 'Ab6', 'A6', 'Bb6', 'B6', 'C7', 'Db7', 'D7', 'Eb7', 'E7', 'F7', 'Gb7', 'G7', 'Ab7', 'A7', 'Bb7', 'B7', 'C8', 'Db8', 'D8', 'Eb8', 'E8', 'F8', 'Gb8', 'G8', 'Ab8', 'A8', 'Bb8', 'B8', 'C9', 'Db9', 'D9', 'Eb9', 'E9', 'F9', 'Gb9', 'G9', 'Ab9', 'A9', 'Bb9', 'B9', 'C10', 'Db10', 'D10', 'Eb10', 'E10', 'F10', 'Gb10', 'G10', 'Ab10', 'A10', 'Bb10', 'B10']
-note_code = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -37,6 +30,13 @@ config.read(args.inifile)
 
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
+
+# the list of MIDI commands is the only aspect that is specific to the Volca Keys
+# see http://media.aadl.org/files/catalog_guides/1444140_chart.pdf
+control_name = ['portamento', 'expression', 'voice', 'octave', 'detune', 'vco_eg_int', 'vcf_cutoff', 'vcf_eg_int', 'lfo_rate', 'lfo_pitch_int', 'lfo_cutoff_int', 'eg_attack', 'eg_decay_release', 'eg_sustain', 'delay_time', 'delay_feedback']
+control_code = [5, 11, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53]
+note_name = ['C0', 'Db0', 'D0', 'Eb0', 'E0', 'F0', 'Gb0', 'G0', 'Ab0', 'A0', 'Bb0', 'B0', 'C1', 'Db1', 'D1', 'Eb1', 'E1', 'F1', 'Gb1', 'G1', 'Ab1', 'A1', 'Bb1', 'B1', 'C2', 'Db2', 'D2', 'Eb2', 'E2', 'F2', 'Gb2', 'G2', 'Ab2', 'A2', 'Bb2', 'B2', 'C3', 'Db3', 'D3', 'Eb3', 'E3', 'F3', 'Gb3', 'G3', 'Ab3', 'A3', 'Bb3', 'B3', 'C4', 'Db4', 'D4', 'Eb4', 'E4', 'F4', 'Gb4', 'G4', 'Ab4', 'A4', 'Bb4', 'B4', 'C5', 'Db5', 'D5', 'Eb5', 'E5', 'F5', 'Gb5', 'G5', 'Ab5', 'A5', 'Bb5', 'B5', 'C6', 'Db6', 'D6', 'Eb6', 'E6', 'F6', 'Gb6', 'G6', 'Ab6', 'A6', 'Bb6', 'B6', 'C7', 'Db7', 'D7', 'Eb7', 'E7', 'F7', 'Gb7', 'G7', 'Ab7', 'A7', 'Bb7', 'B7', 'C8', 'Db8', 'D8', 'Eb8', 'E8', 'F8', 'Gb8', 'G8', 'Ab8', 'A8', 'Bb8', 'B8', 'C9', 'Db9', 'D9', 'Eb9', 'E9', 'F9', 'Gb9', 'G9', 'Ab9', 'A9', 'Bb9', 'B9', 'C10', 'Db10', 'D10', 'Eb10', 'E10', 'F10', 'Gb10', 'G10', 'Ab10', 'A10', 'Bb10', 'B10']
+note_code = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)


### PR DESCRIPTION
for the README files for each module, for the order of the imports, for the order of the initial section (dealing with config and redis etc).

I also made the "sleep" consistent between playback, playbackctrl, and generate signal modules. This overwrites the changes that @stephenwhitmarsh made previously in playbackctrl (which I was not able to follow completely).

 