### PR TITLE
make patching more flexible

### DIFF
--- a/lib/EEGsynth.py
+++ b/lib/EEGsynth.py
@@ -92,7 +92,7 @@ class midiwrapper():
 
 
 class patch():
-    ####################################################################
+    ######################################################################################
     # The formatting of the item in the ini file should be like this
     #   item=1            this returns 1
     #   item=key          get the value of the key from redis
@@ -103,6 +103,7 @@ class patch():
     #   item=key1,key2    get the value of key1 and key2 from redis
     #   item=key1,5       get the value of key1 from redis
     #   item=0,key2       get the value of key2 from redis
+    ######################################################################################
 
     def __init__(self, c, r):
         self.config = c
@@ -128,7 +129,10 @@ class patch():
                     except TypeError:
                         val[i] = default
         else:
-            val = [default]
+            if default != None:
+                val = [float(default)]
+            else:
+                val = [default]
 
         if multiple:
             # return it as list
@@ -159,7 +163,10 @@ class patch():
                     except TypeError:
                         val[i] = default
         else:
-            val = [default]
+            if default != None:
+                val = [int(default)]
+            else:
+                val = [default]
 
         if multiple:
             # return it as list
@@ -170,8 +177,8 @@ class patch():
 
     ####################################################################
     def getstring(self, section, item):
-
-        # get one items from the ini file, multiple items are not yet supported
+        # get one items from the ini file
+        # multiple items and default values are not yet supported
         val = self.config.get(section, item)
         return val
 
@@ -180,11 +187,11 @@ def rescale(xval, slope=None, offset=None):
     if hasattr(xval, "__iter__"):
         return [rescale(x, slope, offset) for x in xval]
     else:
-        if slope is None:
-            slope = 1
-        if offset is None:
-            offset = 0
-        return float(slope)*xval + float(offset)
+        if slope==None:
+            slope = 1.0
+        if offset==None:
+            offset = 0.0
+        return float(slope)*float(xval) + float(offset)
 
 ####################################################################
 def limit(xval, lo=0.0, hi=127.0):

--- a/lib/EEGsynth.py
+++ b/lib/EEGsynth.py
@@ -91,77 +91,89 @@ class midiwrapper():
             raise NameError('unsupported backend: ' + self.backend)
 
 
-####################################################################
-# The formatting of the item in the ini file should be like this
-#   item=1            this returns 1
-#   item=key          get the value of the key from redis
-# or if multiple is True
-#   item=1-20         this returns [1,20]
-#   item=1,2,3        this returns [1,2,3]
-#   item=1,2,3,5-9    this returns [1,2,3,5,9], not [1,2,3,4,5,6,7,8,9]
-#   item=key1,key2    get the value of key1 and key2 from redis
-#   item=key1,5       get the value of key1 from redis
-#   item=0,key2       get the value of key2 from redis
-def getfloat(section, item, config, redis, multiple=False, default=None):
+class patch():
+    ####################################################################
+    # The formatting of the item in the ini file should be like this
+    #   item=1            this returns 1
+    #   item=key          get the value of the key from redis
+    # or if multiple is True
+    #   item=1-20         this returns [1,20]
+    #   item=1,2,3        this returns [1,2,3]
+    #   item=1,2,3,5-9    this returns [1,2,3,5,9], not [1,2,3,4,5,6,7,8,9]
+    #   item=key1,key2    get the value of key1 and key2 from redis
+    #   item=key1,5       get the value of key1 from redis
+    #   item=0,key2       get the value of key2 from redis
 
-    if config.has_option(section, item):
-        # get all items from the ini file, there might be one or multiple
-        items = config.get(section, item)
-        items = items.replace(' ', '')         # remove whitespace
-        if items[0]!='-':
-            items = items.replace('-', ',')    # replace minus separators by commas
-        items = items.split(',')               # split on the commas
-        val = [None]*len(items)
+    def __init__(self, c, r):
+        self.config = c
+        self.redis  = r
 
-        for i,item in enumerate(items):
-            # replace the item with the actual value
-            try:
-                val[i] = float(item)
-            except ValueError:
+    def getfloat(self, section, item, multiple=False, default=None):
+        if  self.config.has_option(section, item):
+            # get all items from the ini file, there might be one or multiple
+            items = self.config.get(section, item)
+            items = items.replace(' ', '')         # remove whitespace
+            if items[0]!='-':
+                items = items.replace('-', ',')    # replace minus separators by commas
+            items = items.split(',')               # split on the commas
+            val = [None]*len(items)
+
+            for i,item in enumerate(items):
+                # replace the item with the actual value
                 try:
-                    val[i] = float(redis.get(item))
-                except TypeError:
-                    val[i] = default
-    else:
-        val = [default]
+                    val[i] = float(item)
+                except ValueError:
+                    try:
+                        val[i] = float(self.redis.get(item))
+                    except TypeError:
+                        val[i] = default
+        else:
+            val = [default]
 
-    if multiple:
-        # return it as list
-        return val
-    else:
-        # return a single value
-        return val[0]
+        if multiple:
+            # return it as list
+            return val
+        else:
+            # return a single value
+            return val[0]
 
-####################################################################
-def getint(section, item, config, redis, multiple=False, default=None):
+    ####################################################################
+    def getint(self, section, item, multiple=False, default=None):
 
-    if config.has_option(section, item):
-        # get all items from the ini file, there might be one or multiple
-        items = config.get(section, item)
-        items = items.replace(' ', '')         # remove whitespace
-        if items[0]!='-':
-            items = items.replace('-', ',')    # replace minus separators by commas
-        items = items.split(',')               # split on the commas
-        val = [None]*len(items)
+        if self.config.has_option(section, item):
+            # get all items from the ini file, there might be one or multiple
+            items = self.config.get(section, item)
+            items = items.replace(' ', '')         # remove whitespace
+            if items[0]!='-':
+                items = items.replace('-', ',')    # replace minus separators by commas
+            items = items.split(',')               # split on the commas
+            val = [None]*len(items)
 
-        for i,item in enumerate(items):
-            # replace the item with the actual value
-            try:
-                val[i] = int(item)
-            except ValueError:
+            for i,item in enumerate(items):
+                # replace the item with the actual value
                 try:
-                    val[i] = int(redis.get(item))
-                except TypeError:
-                    val[i] = default
-    else:
-        val = [default]
+                    val[i] = int(item)
+                except ValueError:
+                    try:
+                        val[i] = int(self.redis.get(item))
+                    except TypeError:
+                        val[i] = default
+        else:
+            val = [default]
 
-    if multiple:
-        # return it as list
+        if multiple:
+            # return it as list
+            return val
+        else:
+            # return a single value
+            return val[0]
+
+    ####################################################################
+    def getstring(self, section, item):
+
+        # get one items from the ini file, multiple items are not yet supported
+        val = self.config.get(section, item)
         return val
-    else:
-        # return a single value
-        return val[0]
 
 ####################################################################
 def rescale(xval, slope=None, offset=None):

--- a/module/accelerometer/accelerometer.py
+++ b/module/accelerometer/accelerometer.py
@@ -48,6 +48,13 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+try:
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print "Error: cannot connect to redis server"
+    exit()
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 # this is the timeout for the FieldTrip buffer
@@ -80,15 +87,6 @@ while hdr_input is None:
 if debug>1:
     print hdr_input
     print hdr_input.labels
-
-try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
-    response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
-except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
-    exit()
 
 # get the processing arameters
 window = config.getfloat('processing','window')*hdr_input.fSample

--- a/module/accelerometer/accelerometer.py
+++ b/module/accelerometer/accelerometer.py
@@ -55,8 +55,13 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
+
 # this is the timeout for the FieldTrip buffer
 timeout = config.getfloat('fieldtrip','timeout')
 

--- a/module/accelerometer/accelerometer.py
+++ b/module/accelerometer/accelerometer.py
@@ -129,21 +129,9 @@ while True:
     for chanstr,chanindx in zip(channel_name, channel_indx):
 
         # the scale option is channel specific
-        if config.has_option('scale', chanstr):
-            try:
-                scale = patch.getfloat('scale', chanstr)
-            except:
-                scale = r.get(patch.getstring('scale', chanstr))
-        else:
-            scale = 1
+        scale = patch.getfloat('scale', chanstr, default=1)
         # the offset option is channel specific
-        if config.has_option('offset', chanstr):
-            try:
-                offset = patch.getfloat('offset', chanstr)
-            except:
-                offset = r.get(patch.getstring('offset', chanstr))
-        else:
-            offset = 0
+        offset = patch.getfloat('offset', chanstr, default=0)
 
         # compute the mean over the window
         val = np.mean(dat[:,chanindx])

--- a/module/accelerometer/accelerometer.py
+++ b/module/accelerometer/accelerometer.py
@@ -60,14 +60,14 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # this is the timeout for the FieldTrip buffer
-timeout = config.getfloat('fieldtrip','timeout')
+timeout = patch.getfloat('fieldtrip','timeout')
 
 try:
-    ftc_host = config.get('fieldtrip','hostname')
-    ftc_port = config.getint('fieldtrip','port')
+    ftc_host = patch.getstring('fieldtrip','hostname')
+    ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
         print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
     ftc = FieldTrip.Client()
@@ -94,19 +94,19 @@ if debug>1:
     print hdr_input.labels
 
 # get the processing arameters
-window = config.getfloat('processing','window')*hdr_input.fSample
+window = patch.getfloat('processing','window')*hdr_input.fSample
 
 channel_indx = []
 channel_name = ['channelX', 'channelY', 'channelZ']
 for chan in channel_name:
     # channel numbers are one-offset in the ini file, zero-offset in the code
-    channel_indx.append(config.getint('input',chan)-1)
+    channel_indx.append(patch.getint('input',chan)-1)
 
 begsample = -1
 endsample = -1
 
 while True:
-    time.sleep(config.getfloat('general','delay'))
+    time.sleep(patch.getfloat('general','delay'))
 
     hdr_input = ftc.getHeader()
     if (hdr_input.nSamples-1)<endsample:
@@ -131,17 +131,17 @@ while True:
         # the scale option is channel specific
         if config.has_option('scale', chanstr):
             try:
-                scale = config.getfloat('scale', chanstr)
+                scale = patch.getfloat('scale', chanstr)
             except:
-                scale = r.get(config.get('scale', chanstr))
+                scale = r.get(patch.getstring('scale', chanstr))
         else:
             scale = 1
         # the offset option is channel specific
         if config.has_option('offset', chanstr):
             try:
-                offset = config.getfloat('offset', chanstr)
+                offset = patch.getfloat('offset', chanstr)
             except:
-                offset = r.get(config.get('offset', chanstr))
+                offset = r.get(patch.getstring('offset', chanstr))
         else:
             offset = 0
 
@@ -157,7 +157,7 @@ while True:
         # this is for debugging
         printval.append(val)
 
-        r.set(config.get('output', 'prefix') + '.' + chanstr, val)
+        r.set(patch.getstring('output', 'prefix') + '.' + chanstr, val)
 
     if debug>1:
         print printval

--- a/module/avmixer/avmixer.py
+++ b/module/avmixer/avmixer.py
@@ -54,6 +54,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -140,7 +144,7 @@ try:
         for name, cmd in zip(control_name, control_code):
             split_name = name.split('/')
             # loop over the control values
-            val = EEGsynth.getint(split_name[0], split_name[1], config, r)
+            val = patch.getint(split_name[0], split_name[1])
             if val is None:
                 continue#  it should be skipped when not present in the ini or redis
             if val==previous_val[name]:

--- a/module/avmixer/avmixer.py
+++ b/module/avmixer/avmixer.py
@@ -47,6 +47,16 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+try:
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print "Error: cannot connect to redis server"
+    exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
+
 # the settings dialog distinguishes three colors for sliders/knobs, buttons and switches
 slider_name = ['mixer/mixer1_mode', 'mixer/mixer1_fader', 'mixer/mixer2_mode', 'mixer/mixer2_fader', 'mixer/fade_to_black', 'color_fx/saturation', 'color_fx/hue1', 'color_fx/black1', 'color_fx/hue2', 'color_fx/black2', 'transform_fx/tile_mode', 'transform_fx/rotate', 'transform_fx/zoom', 'transform_fx/move_x', 'transform_fx/move_y', 'transform_fx/center_x', 'transform_fx/center_y', 'transform_fx/skew_x', 'transform_fx/skew_y', 'freeframe_fx1/pad1_x', 'freeframe_fx1/pad1_y', 'freeframe_fx1/pad2_x', 'freeframe_fx1/pad2_y', 'freeframe_fx1/pad3_x', 'freeframe_fx1/pad4_y', 'freeframe_fx2/pad1_x', 'freeframe_fx2/pad1_y', 'freeframe_fx2/pad2_x', 'freeframe_fx2/pad2_y', 'freeframe_fx2/pad3_x', 'freeframe_fx2/pad4_y', 'channelA/playback_speed', 'channelA/scrub_timeline', 'channelB/playback_speed', 'channelB/scrub_timeline', 'channelC/playback_speed', 'channelC/scrub_timeline']
 slider_code = [31, 32, 33, 34, 35, 45, 0, 0, 0, 0, 0, 53, 54, 56, 55, 58, 57, 60, 59, 69, 68, 71, 70, 73, 72, 82, 81, 84, 83, 86, 85, 3, 10, 14, 20, 24, 30]
@@ -68,18 +78,6 @@ control_name = slider_name
 control_code = slider_code
 note_name = button_name + switch_name
 note_code = button_code + switch_code
-
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
-try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
-    response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
-except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
-    exit()
 
 midichannel = config.getint('midi', 'channel')-1  # channel 1-16 get mapped to 0-15
 outputport = EEGsynth.midiwrapper(config)

--- a/module/avmixer/avmixer.py
+++ b/module/avmixer/avmixer.py
@@ -59,7 +59,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # the settings dialog distinguishes three colors for sliders/knobs, buttons and switches
 slider_name = ['mixer/mixer1_mode', 'mixer/mixer1_fader', 'mixer/mixer2_mode', 'mixer/mixer2_fader', 'mixer/fade_to_black', 'color_fx/saturation', 'color_fx/hue1', 'color_fx/black1', 'color_fx/hue2', 'color_fx/black2', 'transform_fx/tile_mode', 'transform_fx/rotate', 'transform_fx/zoom', 'transform_fx/move_x', 'transform_fx/move_y', 'transform_fx/center_x', 'transform_fx/center_y', 'transform_fx/skew_x', 'transform_fx/skew_y', 'freeframe_fx1/pad1_x', 'freeframe_fx1/pad1_y', 'freeframe_fx1/pad2_x', 'freeframe_fx1/pad2_y', 'freeframe_fx1/pad3_x', 'freeframe_fx1/pad4_y', 'freeframe_fx2/pad1_x', 'freeframe_fx2/pad1_y', 'freeframe_fx2/pad2_x', 'freeframe_fx2/pad2_y', 'freeframe_fx2/pad3_x', 'freeframe_fx2/pad4_y', 'channelA/playback_speed', 'channelA/scrub_timeline', 'channelB/playback_speed', 'channelB/scrub_timeline', 'channelC/playback_speed', 'channelC/scrub_timeline']
@@ -83,7 +83,7 @@ control_code = slider_code
 note_name = button_name + switch_name
 note_code = button_code + switch_code
 
-midichannel = config.getint('midi', 'channel')-1  # channel 1-16 get mapped to 0-15
+midichannel = patch.getint('midi', 'channel')-1  # channel 1-16 get mapped to 0-15
 outputport = EEGsynth.midiwrapper(config)
 outputport.open_output()
 
@@ -120,7 +120,7 @@ for name, code in zip(note_name, note_code):
     split_name = name.split('/')
     if config.has_option(split_name[0], split_name[1]):
         # start the background thread that deals with this note
-        this = TriggerThread(config.get(split_name[0], split_name[1]), code)
+        this = TriggerThread(patch.getstring(split_name[0], split_name[1]), code)
         trigger.append(this)
         if debug>1:
             print name, 'OK'
@@ -139,7 +139,7 @@ for name in control_name:
 
 try:
     while True:
-        time.sleep(config.getfloat('general', 'delay'))
+        time.sleep(patch.getfloat('general', 'delay'))
 
         for name, cmd in zip(control_name, control_code):
             split_name = name.split('/')

--- a/module/calibration/calibration.py
+++ b/module/calibration/calibration.py
@@ -50,17 +50,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 prefix      = config.get('output','prefix')
 inputlist   = config.get('input','channels').split(",")

--- a/module/calibration/calibration.py
+++ b/module/calibration/calibration.py
@@ -62,11 +62,11 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
-prefix      = config.get('output','prefix')
-inputlist   = config.get('input','channels').split(",")
-stepsize    = config.getfloat('calibration','stepsize')   # in seconds
+prefix      = patch.getstring('output','prefix')
+inputlist   = patch.getstring('input','channels').split(",")
+stepsize    = patch.getfloat('calibration','stepsize')   # in seconds
 numchannel  = len(inputlist)
 
 # this will contain the initial and calibrated values

--- a/module/endorphines/endorphines.py
+++ b/module/endorphines/endorphines.py
@@ -59,7 +59,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general', 'debug')
+debug = patch.getint('general', 'debug')
 
 outputport = EEGsynth.midiwrapper(config)
 outputport.open_output()
@@ -95,7 +95,7 @@ class TriggerThread(threading.Thread):
                     outputport.send(msg)
                     lock.release()
                     # keep it at the present value for a minimal amount of time
-                    time.sleep(config.getfloat('general','pulselength'))
+                    time.sleep(patch.getfloat('general','pulselength'))
 
 # each of the gates that can be triggered is mapped onto a different message
 gate = []
@@ -104,7 +104,7 @@ for channel in range(0, 16):
     name = 'channel{}'.format(channel+1)
     if config.has_option('gate', name):
         # start the background thread that deals with this channel
-        this = TriggerThread(config.get('gate', name), channel)
+        this = TriggerThread(patch.getstring('gate', name), channel)
         gate.append(this)
         if debug>1:
             print name, 'OK'
@@ -121,7 +121,7 @@ for channel in range(1, 16):
 
 try:
     while True:
-        time.sleep(config.getfloat('general', 'delay'))
+        time.sleep(patch.getfloat('general', 'delay'))
 
         # loop over the control values
         for channel in range(0, 16):

--- a/module/endorphines/endorphines.py
+++ b/module/endorphines/endorphines.py
@@ -47,17 +47,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general', 'debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general', 'debug')
 
 outputport = EEGsynth.midiwrapper(config)
 outputport.open_output()

--- a/module/eyeblink/eyeblink.py
+++ b/module/eyeblink/eyeblink.py
@@ -60,14 +60,14 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # this is the timeout for the FieldTrip buffer
-timeout = config.getfloat('fieldtrip','timeout')
+timeout = patch.getfloat('fieldtrip','timeout')
 
 try:
-    ftc_host = config.get('fieldtrip','hostname')
-    ftc_port = config.getint('fieldtrip','port')
+    ftc_host = patch.getstring('fieldtrip','hostname')
+    ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
         print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
     ftc = FieldTrip.Client()
@@ -107,7 +107,7 @@ class TriggerThread(threading.Thread):
         self.running = False
     def run(self):
         pubsub = self.r.pubsub()
-        channel = self.config.get('processing','calibrate')
+        channel = self.patch.getstring('processing','calibrate')
         pubsub.subscribe('EYEBLINK_UNBLOCK')  # this message unblocks the redis listen command
         pubsub.subscribe(channel)
         while self.running:
@@ -125,8 +125,8 @@ try:
     trigger = TriggerThread(r, config)
     trigger.start()
 
-    channel = config.getint('input','channel')-1                         # one-offset in the ini file, zero-offset in the code
-    window  = round(config.getfloat('processing','window') * hdr_input.fSample)  # in samples
+    channel = patch.getint('input','channel')-1                         # one-offset in the ini file, zero-offset in the code
+    window  = round(patch.getfloat('processing','window') * hdr_input.fSample)  # in samples
 
     minval = None
     maxval = None
@@ -137,7 +137,7 @@ try:
     endsample = -1
 
     while True:
-        time.sleep(config.getfloat('processing','window')/10)
+        time.sleep(patch.getfloat('processing','window')/10)
         t += 1
 
         lock.acquire()
@@ -160,17 +160,17 @@ try:
         D = D[:,channel]
 
         try:
-            low_pass = config.getint('processing', 'low_pass')
+            low_pass = patch.getint('processing', 'low_pass')
         except:
             low_pass = None
 
         try:
-            high_pass = config.getint('processing', 'high_pass')
+            high_pass = patch.getint('processing', 'high_pass')
         except:
             high_pass = None
 
         try:
-            order = config.getint('general', 'order')
+            order = patch.getint('general', 'order')
         except:
             order = None
 
@@ -187,7 +187,7 @@ try:
         maxval = max(maxval,np.max(D))
 
         spread = np.max(D) - np.min(D)
-        if spread > config.getfloat('processing','threshold')*(maxval-minval):
+        if spread > patch.getfloat('processing','threshold')*(maxval-minval):
             val = 1
         else:
             val = 0
@@ -196,7 +196,7 @@ try:
               '\t  max_spread : ' + str(maxval-minval) +
               '\t  output ' + str(val))
 
-        key = "%s.channel%d" % (config.get('output','prefix'), channel+1)
+        key = "%s.channel%d" % (patch.getstring('output','prefix'), channel+1)
         r.publish(key,val)
 
 except (KeyboardInterrupt, SystemExit):

--- a/module/eyeblink/eyeblink.py
+++ b/module/eyeblink/eyeblink.py
@@ -55,8 +55,13 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
+
 # this is the timeout for the FieldTrip buffer
 timeout = config.getfloat('fieldtrip','timeout')
 

--- a/module/eyeblink/eyeblink.py
+++ b/module/eyeblink/eyeblink.py
@@ -48,19 +48,17 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+try:
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print "Error: cannot connect to redis server"
+    exit()
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 # this is the timeout for the FieldTrip buffer
 timeout = config.getfloat('fieldtrip','timeout')
-
-try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
-    response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
-except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
-    exit()
 
 try:
     ftc_host = config.get('fieldtrip','hostname')

--- a/module/generatecontrol/generatecontrol.py
+++ b/module/generatecontrol/generatecontrol.py
@@ -53,11 +53,14 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
-update = config.getfloat('generate', 'update') # in seconds
-
+update            = config.getfloat('generate', 'update') # in seconds
 scale_frequency   = config.getfloat('scale', 'frequency')
 scale_amplitude   = config.getfloat('scale', 'amplitude')
 scale_offset      = config.getfloat('scale', 'offset')
@@ -79,10 +82,10 @@ while True:
     # measure the time that it takes
     start = time.time();
 
-    frequency = EEGsynth.getfloat('signal', 'frequency', config, r, default=1)  * scale_frequency
-    amplitude = EEGsynth.getfloat('signal', 'amplitude', config, r, default=1)  * scale_amplitude
-    offset    = EEGsynth.getfloat('signal', 'offset', config, r, default=0)     * scale_offset
-    noise     = EEGsynth.getfloat('signal', 'noise', config, r, default=0.5)    * scale_noise
+    frequency = patch.getfloat('signal', 'frequency', default=1)  * scale_frequency
+    amplitude = patch.getfloat('signal', 'amplitude', default=1)  * scale_amplitude
+    offset    = patch.getfloat('signal', 'offset', default=0)     * scale_offset
+    noise     = patch.getfloat('signal', 'noise', default=0.5)    * scale_noise
 
     if frequency != prev_frequency:
         print "frequency", frequency

--- a/module/generatecontrol/generatecontrol.py
+++ b/module/generatecontrol/generatecontrol.py
@@ -58,13 +58,13 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
-update            = config.getfloat('generate', 'update') # in seconds
-scale_frequency   = config.getfloat('scale', 'frequency')
-scale_amplitude   = config.getfloat('scale', 'amplitude')
-scale_offset      = config.getfloat('scale', 'offset')
-scale_noise       = config.getfloat('scale', 'noise')
+update            = patch.getfloat('generate', 'update') # in seconds
+scale_frequency   = patch.getfloat('scale', 'frequency')
+scale_amplitude   = patch.getfloat('scale', 'amplitude')
+scale_offset      = patch.getfloat('scale', 'offset')
+scale_noise       = patch.getfloat('scale', 'noise')
 
 if debug > 1:
     print "update", update
@@ -103,19 +103,19 @@ while True:
     t = sample * update
     sample += 1
 
-    key = config.get('output', 'prefix') + '.sin'
+    key = patch.getstring('output', 'prefix') + '.sin'
     val = np.sin(2 * np.pi * frequency * t) * amplitude + np.random.randn(1) * noise
     r.set(key, val[0])
 
-    key = config.get('output', 'prefix') + '.square'
+    key = patch.getstring('output', 'prefix') + '.square'
     val = signal.square(2 * np.pi * frequency * t, 0.5) * amplitude + np.random.randn(1) * noise
     r.set(key, val[0])
 
-    key = config.get('output', 'prefix') + '.triangle'
+    key = patch.getstring('output', 'prefix') + '.triangle'
     val = signal.sawtooth(2 * np.pi * frequency * t, 0.5) * amplitude + np.random.randn(1) * noise
     r.set(key, val[0])
 
-    key = config.get('output', 'prefix') + '.sawtooth'
+    key = patch.getstring('output', 'prefix') + '.sawtooth'
     val = signal.sawtooth(2 * np.pi * frequency * t, 1) * amplitude + np.random.randn(1) * noise
     r.set(key, val[0])
 

--- a/module/generatecontrol/generatecontrol.py
+++ b/module/generatecontrol/generatecontrol.py
@@ -46,15 +46,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 update = config.getfloat('generate', 'update') # in seconds
 

--- a/module/generatesignal/generatesignal.py
+++ b/module/generatesignal/generatesignal.py
@@ -59,11 +59,11 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 try:
-    ftc_host = config.get('fieldtrip','hostname')
-    ftc_port = config.getint('fieldtrip','port')
+    ftc_host = patch.getstring('fieldtrip','hostname')
+    ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
         print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
     ft_output = FieldTrip.Client()
@@ -75,9 +75,9 @@ except:
     exit()
 
 datatype  = FieldTrip.DATATYPE_FLOAT32
-nchannels = config.getint('generate', 'nchannels')
-fsample   = config.getfloat('generate', 'fsample')
-blocksize = int(round(config.getfloat('generate', 'window') * fsample))
+nchannels = patch.getint('generate', 'nchannels')
+fsample   = patch.getfloat('generate', 'fsample')
+blocksize = int(round(patch.getfloat('generate', 'window') * fsample))
 
 ft_output.putHeader(nchannels, fsample, datatype)
 
@@ -86,9 +86,9 @@ if debug > 1:
     print "fsample", fsample
     print "blocksize", blocksize
 
-scale_frequency   = config.getfloat('scale', 'frequency')
-scale_amplitude   = config.getfloat('scale', 'amplitude')
-scale_noise       = config.getfloat('scale', 'noise')
+scale_frequency   = patch.getfloat('scale', 'frequency')
+scale_amplitude   = patch.getfloat('scale', 'amplitude')
+scale_noise       = patch.getfloat('scale', 'noise')
 
 prev_frequency = -1
 prev_amplitude = -1

--- a/module/generatesignal/generatesignal.py
+++ b/module/generatesignal/generatesignal.py
@@ -54,6 +54,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -103,9 +107,9 @@ while True:
     if debug>1:
         print "Generating block", block, 'from', begsample, 'to', endsample
 
-    frequency = EEGsynth.getfloat('signal', 'frequency', config, r, default=10) * scale_frequency
-    amplitude = EEGsynth.getfloat('signal', 'amplitude', config, r, default=1)  * scale_amplitude
-    noise     = EEGsynth.getfloat('signal', 'noise', config, r, default=0.5)    * scale_noise
+    frequency = patch.getfloat('signal', 'frequency', default=10) * scale_frequency
+    amplitude = patch.getfloat('signal', 'amplitude', default=1)  * scale_amplitude
+    noise     = patch.getfloat('signal', 'noise', default=0.5)    * scale_noise
 
     if frequency != prev_frequency:
         print "frequency", frequency

--- a/module/generatesignal/generatesignal.py
+++ b/module/generatesignal/generatesignal.py
@@ -47,15 +47,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 try:
     ftc_host = config.get('fieldtrip','hostname')

--- a/module/heartrate/heartrate.py
+++ b/module/heartrate/heartrate.py
@@ -54,8 +54,13 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
+
 # this is the timeout for the FieldTrip buffer
 timeout = config.getfloat('fieldtrip','timeout')
 

--- a/module/heartrate/heartrate.py
+++ b/module/heartrate/heartrate.py
@@ -59,14 +59,14 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # this is the timeout for the FieldTrip buffer
-timeout = config.getfloat('fieldtrip','timeout')
+timeout = patch.getfloat('fieldtrip','timeout')
 
 try:
-    ftc_host = config.get('fieldtrip','hostname')
-    ftc_port = config.getint('fieldtrip','port')
+    ftc_host = patch.getstring('fieldtrip','hostname')
+    ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
         print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
     ftc = FieldTrip.Client()
@@ -94,15 +94,15 @@ if debug>1:
 
 
 filter_length = '3s'
-window  = round(config.getfloat('processing','window') * hdr_input.fSample) # in samples
-channel = config.getint('input','channel')-1                        # one-offset in the ini file, zero-offset in the code
-key     = "%s.channel%d" % (config.get('output','prefix'), channel+1)
+window  = round(patch.getfloat('processing','window') * hdr_input.fSample) # in samples
+channel = patch.getint('input','channel')-1                        # one-offset in the ini file, zero-offset in the code
+key     = "%s.channel%d" % (patch.getstring('output','prefix'), channel+1)
 
 begsample = -1
 endsample = -1
 
 while True:
-    time.sleep(config.getfloat('general','delay'))
+    time.sleep(patch.getfloat('general','delay'))
 
     hdr_input = ftc.getHeader()
     if (hdr_input.nSamples-1)<endsample:

--- a/module/heartrate/heartrate.py
+++ b/module/heartrate/heartrate.py
@@ -47,6 +47,13 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+try:
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print "Error: cannot connect to redis server"
+    exit()
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 # this is the timeout for the FieldTrip buffer
@@ -80,14 +87,6 @@ if debug>1:
     print hdr_input
     print hdr_input.labels
 
-try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
-    response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
-except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
-    exit()
 
 filter_length = '3s'
 window  = round(config.getfloat('processing','window') * hdr_input.fSample) # in samples

--- a/module/inputmidi/inputmidi.py
+++ b/module/inputmidi/inputmidi.py
@@ -58,7 +58,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # this is only for debugging
 print('------ INPUT ------')
@@ -67,7 +67,7 @@ for port in mido.get_input_names():
 print('-------------------------')
 
 try:
-    inputport  = mido.open_input(config.get('midi', 'device'))
+    inputport  = mido.open_input(patch.getstring('midi', 'device'))
     if debug>0:
         print "Connected to MIDI input"
 except:
@@ -75,7 +75,7 @@ except:
     exit()
 
 while True:
-    time.sleep(config.getfloat('general','delay'))
+    time.sleep(patch.getfloat('general','delay'))
 
     for msg in inputport.iter_pending():
 
@@ -84,16 +84,16 @@ while True:
 
         if hasattr(msg, "control"):
             # prefix.control000=value
-            key = "{}.control{:0>3d}".format(config.get('output', 'prefix'), msg.control)
+            key = "{}.control{:0>3d}".format(patch.getstring('output', 'prefix'), msg.control)
             val = msg.value
             r.set(key, val)
 
         elif hasattr(msg, "note"):
             # prefix.noteXXX=value
-            key = "{}.note{:0>3d}".format(config.get('output','prefix'), msg.note)
+            key = "{}.note{:0>3d}".format(patch.getstring('output','prefix'), msg.note)
             r.set(key,msg.value)          # send it as control value
             r.publish(key,msg.value)      # send it as trigger
             # prefix.note=note
-            key = "{}.note".format(config.get('output','prefix'))
+            key = "{}.note".format(patch.getstring('output','prefix'))
             r.set(key,msg.note)          # send it as control value
             r.publish(key,msg.note)      # send it as trigger

--- a/module/inputmidi/inputmidi.py
+++ b/module/inputmidi/inputmidi.py
@@ -46,15 +46,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 # this is only for debugging
 print('------ INPUT ------')

--- a/module/inputmidi/inputmidi.py
+++ b/module/inputmidi/inputmidi.py
@@ -53,6 +53,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 

--- a/module/inputosc/inputosc.py
+++ b/module/inputosc/inputosc.py
@@ -60,10 +60,10 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 try:
-    s = OSC.OSCServer((config.get('osc','address'), config.getint('osc','port')))
+    s = OSC.OSCServer((patch.getstring('osc','address'), patch.getint('osc','port')))
     if debug>0:
         print "Started OSC server"
 except:
@@ -72,7 +72,7 @@ except:
     exit()
 
 # this is a list of OSC messages that are to be processed as button presses, i.e. using a pubsub message in redis
-button_list = config.get('button', 'push').split(',')
+button_list = patch.getstring('button', 'push').split(',')
 
 # define a message-handler function for the server to call.
 def forward_handler(addr, tags, data, source):
@@ -96,7 +96,7 @@ def forward_handler(addr, tags, data, source):
         data[i] = EEGsynth.rescale(data[i], scale, offset)
 
     # the results will be written to redis as "osc.1.faderA" etc.
-    key = config.get('output', 'prefix') + addr.replace('/', '.')
+    key = patch.getstring('output', 'prefix') + addr.replace('/', '.')
 
     if tags=='f' or tags=='i':
         # it is a single value

--- a/module/inputosc/inputosc.py
+++ b/module/inputosc/inputosc.py
@@ -48,17 +48,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Started OSC server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 try:
     s = OSC.OSCServer((config.get('osc','address'), config.getint('osc','port')))

--- a/module/inputosc/inputosc.py
+++ b/module/inputosc/inputosc.py
@@ -55,6 +55,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -79,11 +83,11 @@ def forward_handler(addr, tags, data, source):
     print "data   %s" % data
 
 
-    scale = EEGsynth.getfloat('processing', 'scale', config, r)
+    scale = patch.getfloat('processing', 'scale')
     if scale is None:
         scale = 1
 
-    offset = EEGsynth.getfloat('processing', 'offset', config, r)
+    offset = patch.getfloat('processing', 'offset')
     if offset is None:
         offset = 0
 

--- a/module/keyboard/keyboard.py
+++ b/module/keyboard/keyboard.py
@@ -52,15 +52,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print 'Error: cannot connect to redis server'
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 # this is only for debugging
 print('------ INPUT ------')

--- a/module/keyboard/keyboard.py
+++ b/module/keyboard/keyboard.py
@@ -59,6 +59,10 @@ except redis.ConnectionError:
     print 'Error: cannot connect to redis server'
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 

--- a/module/keyboard/keyboard.py
+++ b/module/keyboard/keyboard.py
@@ -64,7 +64,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # this is only for debugging
 print('------ INPUT ------')
@@ -75,7 +75,7 @@ for port in mido.get_output_names():
   print(port)
 print('-------------------------')
 
-mididevice = config.get('midi', 'device')
+mididevice = patch.getstring('midi', 'device')
 try:
     inputport  = mido.open_input(mididevice)
     if debug>0:
@@ -94,7 +94,7 @@ except:
 
 try:
     # channel 1-16 in the ini file should be mapped to 0-15
-    midichannel = config.getint('midi', 'channel')-1
+    midichannel = patch.getint('midi', 'channel')-1
 except:
     # this happens if it is not specified in the ini file
     # it will be determined on the basis of the first incoming message
@@ -136,7 +136,7 @@ trigger = []
 for name, code in zip(note_name, note_code):
     if config.has_option('input', name):
         # start the background thread that deals with this note
-        this = TriggerThread(config.get('input', name), code)
+        this = TriggerThread(patch.getstring('input', name), code)
         trigger.append(this)
         if debug>1:
             print name, 'OK'
@@ -147,7 +147,7 @@ for thread in trigger:
 
 try:
     while True:
-        time.sleep(config.getfloat('general','delay'))
+        time.sleep(patch.getfloat('general','delay'))
 
         for msg in inputport.iter_pending():
             if midichannel is None:
@@ -162,18 +162,18 @@ try:
 
             if hasattr(msg,'note'):
                 print(msg)
-                if config.get('processing','detect')=='release' and msg.velocity>0:
+                if patch.getstring('processing','detect')=='release' and msg.velocity>0:
                     pass
-                elif config.get('processing','detect')=='press' and msg.velocity==0:
+                elif patch.getstring('processing','detect')=='press' and msg.velocity==0:
                     pass
                 else:
                     # prefix.note=note
-                    key = '{}.note'.format(config.get('output','prefix'))
+                    key = '{}.note'.format(patch.getstring('output','prefix'))
                     val = msg.note
                     r.set(key,val)          # send it as control value
                     r.publish(key,val)      # send it as trigger
                     # prefix.noteXXX=velocity
-                    key = '{}.note{:0>3d}'.format(config.get('output','prefix'), msg.note)
+                    key = '{}.note{:0>3d}'.format(patch.getstring('output','prefix'), msg.note)
                     val = msg.velocity
                     r.set(key,val)          # send it as control value
                     r.publish(key,val)      # send it as trigger

--- a/module/keyboard/keyboard.py
+++ b/module/keyboard/keyboard.py
@@ -61,7 +61,7 @@ except redis.ConnectionError:
 
 # combine the patching from the configuration file and Redis
 patch = EEGsynth.patch(config, r)
-del config
+# del config
 
 # this determines how much debugging information gets printed
 debug = patch.getint('general','debug')

--- a/module/launchcontrol/launchcontrol.py
+++ b/module/launchcontrol/launchcontrol.py
@@ -47,7 +47,7 @@ config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
 try:
-    r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
@@ -72,13 +72,13 @@ print('-------------------------')
 # on windows the input and output are different, on unix they are the same
 # use "input/output" when specified, or otherwise use "device" for both
 try:
-    mididevice_input = patch.getstring('midi', 'input')
+    mididevice_input = patch.getstringstring('midi', 'input')
 except:
-    mididevice_input = patch.getstring('midi', 'device') # fallback
+    mididevice_input = patch.getstringstring('midi', 'device') # fallback
 try:
-    mididevice_output = patch.getstring('midi', 'output')
+    mididevice_output = patch.getstringstring('midi', 'output')
 except:
-    mididevice_output = patch.getstring('midi', 'device') # fallback
+    mididevice_output = patch.getstringstring('midi', 'device') # fallback
 
 print mididevice_input
 print mididevice_output
@@ -109,27 +109,27 @@ except:
 
 try:
     # momentary push button
-    push = [int(a) for a in patch.getstring('button', 'push').split(",")]
+    push = [int(a) for a in patch.getstringstring('button', 'push').split(",")]
 except:
     push = []
 try:
     # on-off button
-    toggle1 = [int(a) for a in patch.getstring('button', 'toggle1').split(",")]
+    toggle1 = [int(a) for a in patch.getstringstring('button', 'toggle1').split(",")]
 except:
     toggle1 = []
 try:
     # on1-on2-off button
-    toggle2 = [int(a) for a in patch.getstring('button', 'toggle2').split(",")]
+    toggle2 = [int(a) for a in patch.getstringstring('button', 'toggle2').split(",")]
 except:
     toggle2 = []
 try:
     # on1-on2-on3-off button
-    toggle3 = [int(a) for a in patch.getstring('button', 'toggle3').split(",")]
+    toggle3 = [int(a) for a in patch.getstringstring('button', 'toggle3').split(",")]
 except:
     toggle3 = []
 try:
     # on1-on2-on3-on4-off button
-    toggle4 = [int(a) for a in patch.getstring('button', 'toggle4').split(",")]
+    toggle4 = [int(a) for a in patch.getstringstring('button', 'toggle4').split(",")]
 except:
     toggle4 = []
 
@@ -206,7 +206,7 @@ while True:
 
         if hasattr(msg, "control"):
             # e.g. prefix.control000=value
-            key = "{}.control{:0>3d}".format(patch.getstring('output', 'prefix'), msg.control)
+            key = "{}.control{:0>3d}".format(patch.getstringstring('output', 'prefix'), msg.control)
             val = EEGsynth.rescale(msg.value, slope=scalecontrol, offset=offsetcontrol)
             r.set(key, val)
 
@@ -264,11 +264,11 @@ while True:
 
             if not val is None:
                 # prefix.noteXXX=value
-                key = "{}.note{:0>3d}".format(patch.getstring('output', 'prefix'), msg.note)
+                key = "{}.note{:0>3d}".format(patch.getstringstring('output', 'prefix'), msg.note)
                 val = EEGsynth.rescale(val, slope=scalenote, offset=offsetnote)
                 r.set(key, val)          # send it as control value
                 r.publish(key, val)      # send it as trigger
                 # prefix.note=note
-                key = "{}.note".format(patch.getstring('output', 'prefix'))
+                key = "{}.note".format(patch.getstringstring('output', 'prefix'))
                 r.set(key, msg.note)          # send it as control value
                 r.publish(key, msg.note)      # send it as trigger

--- a/module/launchcontrol/launchcontrol.py
+++ b/module/launchcontrol/launchcontrol.py
@@ -1,4 +1,4 @@
-env python
+#!/usr/bin/env python
 
 # Launchcontrol interfaces with the Novation LaunchControl
 #
@@ -72,13 +72,13 @@ print('-------------------------')
 # on windows the input and output are different, on unix they are the same
 # use "input/output" when specified, or otherwise use "device" for both
 try:
-    mididevice_input = patch.getstringstring('midi', 'input')
+    mididevice_input = patch.getstring('midi', 'input')
 except:
-    mididevice_input = patch.getstringstring('midi', 'device') # fallback
+    mididevice_input = patch.getstring('midi', 'device') # fallback
 try:
-    mididevice_output = patch.getstringstring('midi', 'output')
+    mididevice_output = patch.getstring('midi', 'output')
 except:
-    mididevice_output = patch.getstringstring('midi', 'device') # fallback
+    mididevice_output = patch.getstring('midi', 'device') # fallback
 
 print mididevice_input
 print mididevice_output
@@ -109,27 +109,27 @@ except:
 
 try:
     # momentary push button
-    push = [int(a) for a in patch.getstringstring('button', 'push').split(",")]
+    push = [int(a) for a in patch.getstring('button', 'push').split(",")]
 except:
     push = []
 try:
     # on-off button
-    toggle1 = [int(a) for a in patch.getstringstring('button', 'toggle1').split(",")]
+    toggle1 = [int(a) for a in patch.getstring('button', 'toggle1').split(",")]
 except:
     toggle1 = []
 try:
     # on1-on2-off button
-    toggle2 = [int(a) for a in patch.getstringstring('button', 'toggle2').split(",")]
+    toggle2 = [int(a) for a in patch.getstring('button', 'toggle2').split(",")]
 except:
     toggle2 = []
 try:
     # on1-on2-on3-off button
-    toggle3 = [int(a) for a in patch.getstringstring('button', 'toggle3').split(",")]
+    toggle3 = [int(a) for a in patch.getstring('button', 'toggle3').split(",")]
 except:
     toggle3 = []
 try:
     # on1-on2-on3-on4-off button
-    toggle4 = [int(a) for a in patch.getstringstring('button', 'toggle4').split(",")]
+    toggle4 = [int(a) for a in patch.getstring('button', 'toggle4').split(",")]
 except:
     toggle4 = []
 
@@ -206,7 +206,7 @@ while True:
 
         if hasattr(msg, "control"):
             # e.g. prefix.control000=value
-            key = "{}.control{:0>3d}".format(patch.getstringstring('output', 'prefix'), msg.control)
+            key = "{}.control{:0>3d}".format(patch.getstring('output', 'prefix'), msg.control)
             val = EEGsynth.rescale(msg.value, slope=scalecontrol, offset=offsetcontrol)
             r.set(key, val)
 
@@ -264,11 +264,11 @@ while True:
 
             if not val is None:
                 # prefix.noteXXX=value
-                key = "{}.note{:0>3d}".format(patch.getstringstring('output', 'prefix'), msg.note)
+                key = "{}.note{:0>3d}".format(patch.getstring('output', 'prefix'), msg.note)
                 val = EEGsynth.rescale(val, slope=scalenote, offset=offsetnote)
                 r.set(key, val)          # send it as control value
                 r.publish(key, val)      # send it as trigger
                 # prefix.note=note
-                key = "{}.note".format(patch.getstringstring('output', 'prefix'))
+                key = "{}.note".format(patch.getstring('output', 'prefix'))
                 r.set(key, msg.note)          # send it as control value
                 r.publish(key, msg.note)      # send it as trigger

--- a/module/launchcontrol/launchcontrol.py
+++ b/module/launchcontrol/launchcontrol.py
@@ -46,15 +46,19 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general', 'debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
+# this determines how much debugging information gets printed
+debug = patch.getint('general', 'debug')
 
 # this is only for debugging, and check which MIDI devices are accessible
 print('------ INPUT ------')
@@ -68,13 +72,16 @@ print('-------------------------')
 # on windows the input and output are different, on unix they are the same
 # use "input/output" when specified, or otherwise use "device" for both
 try:
-    mididevice_input = config.get('midi', 'input')
+    mididevice_input = patch.getstring('midi', 'input')
 except:
-    mididevice_input = config.get('midi', 'device') # fallback
+    mididevice_input = patch.getstring('midi', 'device') # fallback
 try:
-    mididevice_output = config.get('midi', 'output')
+    mididevice_output = patch.getstring('midi', 'output')
 except:
-    mididevice_output = config.get('midi', 'device') # fallback
+    mididevice_output = patch.getstring('midi', 'device') # fallback
+
+print mididevice_input
+print mididevice_output
 
 try:
     inputport = mido.open_input(mididevice_input)
@@ -94,7 +101,7 @@ except:
 
 try:
     # channel 1-16 in the ini file should be mapped to 0-15
-    midichannel = config.getint('midi', 'channel')-1
+    midichannel = patch.getint('midi', 'channel')-1
 except:
     # this happens if it is not specified in the ini file
     # it will be determined on the basis of the first incoming message
@@ -102,27 +109,27 @@ except:
 
 try:
     # momentary push button
-    push = [int(a) for a in config.get('button', 'push').split(",")]
+    push = [int(a) for a in patch.getstring('button', 'push').split(",")]
 except:
     push = []
 try:
     # on-off button
-    toggle1 = [int(a) for a in config.get('button', 'toggle1').split(",")]
+    toggle1 = [int(a) for a in patch.getstring('button', 'toggle1').split(",")]
 except:
     toggle1 = []
 try:
     # on1-on2-off button
-    toggle2 = [int(a) for a in config.get('button', 'toggle2').split(",")]
+    toggle2 = [int(a) for a in patch.getstring('button', 'toggle2').split(",")]
 except:
     toggle2 = []
 try:
     # on1-on2-on3-off button
-    toggle3 = [int(a) for a in config.get('button', 'toggle3').split(",")]
+    toggle3 = [int(a) for a in patch.getstring('button', 'toggle3').split(",")]
 except:
     toggle3 = []
 try:
     # on1-on2-on3-on4-off button
-    toggle4 = [int(a) for a in config.get('button', 'toggle4').split(",")]
+    toggle4 = [int(a) for a in patch.getstring('button', 'toggle4').split(",")]
 except:
     toggle4 = []
 
@@ -178,13 +185,13 @@ state4color  = {0:Off, 41:Red_Full, 43:Yellow_Full, 45:Green_Full, 47:Amber_Full
 state4value  = {0:0, 41:int(127*1/4), 43:int(127*2/4), 45:int(127*3/4), 47:int(127*4/4)}
 
 # it is preferred to use floating point control values between 0 and 1
-scalenote     = config.getfloat('scale', 'note')
-scalecontrol  = config.getfloat('scale', 'control')
-offsetnote    = config.getfloat('offset', 'note')
-offsetcontrol = config.getfloat('offset', 'control')
+scalenote     = patch.getfloat('scale', 'note')
+scalecontrol  = patch.getfloat('scale', 'control')
+offsetnote    = patch.getfloat('offset', 'note')
+offsetcontrol = patch.getfloat('offset', 'control')
 
 while True:
-    time.sleep(config.getfloat('general', 'delay'))
+    time.sleep(patch.getfloat('general', 'delay'))
 
     for msg in inputport.iter_pending():
         if midichannel is None:
@@ -199,7 +206,7 @@ while True:
 
         if hasattr(msg, "control"):
             # e.g. prefix.control000=value
-            key = "{}.control{:0>3d}".format(config.get('output', 'prefix'), msg.control)
+            key = "{}.control{:0>3d}".format(patch.getstring('output', 'prefix'), msg.control)
             val = EEGsynth.rescale(msg.value, slope=scalecontrol, offset=offsetcontrol)
             r.set(key, val)
 
@@ -257,11 +264,11 @@ while True:
 
             if not val is None:
                 # prefix.noteXXX=value
-                key = "{}.note{:0>3d}".format(config.get('output', 'prefix'), msg.note)
+                key = "{}.note{:0>3d}".format(patch.getstring('output', 'prefix'), msg.note)
                 val = EEGsynth.rescale(val, slope=scalenote, offset=offsetnote)
                 r.set(key, val)          # send it as control value
                 r.publish(key, val)      # send it as trigger
                 # prefix.note=note
-                key = "{}.note".format(config.get('output', 'prefix'))
+                key = "{}.note".format(patch.getstring('output', 'prefix'))
                 r.set(key, msg.note)          # send it as control value
                 r.publish(key, msg.note)      # send it as trigger

--- a/module/launchcontrol/launchcontrol.py
+++ b/module/launchcontrol/launchcontrol.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+env python
 
 # Launchcontrol interfaces with the Novation LaunchControl
 #

--- a/module/launchpad/launchpad.py
+++ b/module/launchpad/launchpad.py
@@ -46,15 +46,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 # this is only for debugging
 print('------ INPUT ------')

--- a/module/launchpad/launchpad.py
+++ b/module/launchpad/launchpad.py
@@ -47,7 +47,7 @@ config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
 try:
-    r = redis.StrictRedis(host=patch.get('redis','hostname'), port=patch.getint('redis','port'), db=0)
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
@@ -69,7 +69,7 @@ for port in mido.get_output_names():
   print(port)
 print('-------------------------')
 
-mididevice = patch.get('midi', 'device')
+mididevice = patch.getstring('midi', 'device')
 try:
     inputport  = mido.open_input(mididevice)
     if debug>0:
@@ -96,27 +96,27 @@ except:
 
 try:
     # momentary push button
-    push     = [int(a) for a in patch.get('button', 'push').split(",")]
+    push     = [int(a) for a in patch.getstring('button', 'push').split(",")]
 except:
     push     = []
 try:
     # on-off button
-    toggle1  = [int(a) for a in patch.get('button', 'toggle1').split(",")]
+    toggle1  = [int(a) for a in patch.getstring('button', 'toggle1').split(",")]
 except:
     toggle1  = []
 try:
     # on1-on2-off button
-    toggle2  = [int(a) for a in patch.get('button', 'toggle2').split(",")]
+    toggle2  = [int(a) for a in patch.getstring('button', 'toggle2').split(",")]
 except:
     toggle2  = []
 try:
     # on1-on2-on3-off button
-    toggle3  = [int(a) for a in patch.get('button', 'toggle3').split(",")]
+    toggle3  = [int(a) for a in patch.getstring('button', 'toggle3').split(",")]
 except:
     toggle3  = []
 try:
     # on1-on2-on3-on4-off button
-    toggle4  = [int(a) for a in patch.get('button', 'toggle4').split(",")]
+    toggle4  = [int(a) for a in patch.getstring('button', 'toggle4').split(",")]
 except:
     toggle4  = []
 
@@ -190,7 +190,7 @@ while True:
 
         if hasattr(msg, "control"):
             # prefix.control000=value
-            key = "{}.control{:0>3d}".format(patch.get('output', 'prefix'), msg.control)
+            key = "{}.control{:0>3d}".format(patch.getstring('output', 'prefix'), msg.control)
             val = msg.value
             r.set(key, val)
 
@@ -243,11 +243,11 @@ while True:
 
             if not val is None:
                 # prefix.noteXXX=value
-                key = "{}.note{:0>3d}".format(patch.get('output','prefix'), msg.note)
+                key = "{}.note{:0>3d}".format(patch.getstring('output','prefix'), msg.note)
                 val = EEGsynth.rescale(val, slope=notescale, offset=noteoffset)
                 r.set(key, val)          # send it as control value
                 r.publish(key, val)      # send it as trigger
                 # prefix.note=note
-                key = "{}.note".format(patch.get('output','prefix'))
+                key = "{}.note".format(patch.getstring('output','prefix'))
                 r.set(key, msg.note)          # send it as control value
                 r.publish(key, msg.note)      # send it as trigger

--- a/module/launchpad/launchpad.py
+++ b/module/launchpad/launchpad.py
@@ -47,14 +47,18 @@ config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
 try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    r = redis.StrictRedis(host=patch.get('redis','hostname'), port=patch.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # this is only for debugging
 print('------ INPUT ------')
@@ -65,7 +69,7 @@ for port in mido.get_output_names():
   print(port)
 print('-------------------------')
 
-mididevice = config.get('midi', 'device')
+mididevice = patch.get('midi', 'device')
 try:
     inputport  = mido.open_input(mididevice)
     if debug>0:
@@ -84,7 +88,7 @@ except:
 
 try:
     # channel 1-16 in the ini file should be mapped to 0-15
-    midichannel = config.getint('midi', 'channel')-1
+    midichannel = patch.getint('midi', 'channel')-1
 except:
     # this happens if it is not specified in the ini file
     # it will be determined on the basis of the first incoming message
@@ -92,27 +96,27 @@ except:
 
 try:
     # momentary push button
-    push     = [int(a) for a in config.get('button', 'push').split(",")]
+    push     = [int(a) for a in patch.get('button', 'push').split(",")]
 except:
     push     = []
 try:
     # on-off button
-    toggle1  = [int(a) for a in config.get('button', 'toggle1').split(",")]
+    toggle1  = [int(a) for a in patch.get('button', 'toggle1').split(",")]
 except:
     toggle1  = []
 try:
     # on1-on2-off button
-    toggle2  = [int(a) for a in config.get('button', 'toggle2').split(",")]
+    toggle2  = [int(a) for a in patch.get('button', 'toggle2').split(",")]
 except:
     toggle2  = []
 try:
     # on1-on2-on3-off button
-    toggle3  = [int(a) for a in config.get('button', 'toggle3').split(",")]
+    toggle3  = [int(a) for a in patch.get('button', 'toggle3').split(",")]
 except:
     toggle3  = []
 try:
     # on1-on2-on3-on4-off button
-    toggle4  = [int(a) for a in config.get('button', 'toggle4').split(",")]
+    toggle4  = [int(a) for a in patch.get('button', 'toggle4').split(",")]
 except:
     toggle4  = []
 
@@ -167,11 +171,11 @@ state4color  = {0:Off, 41:Red_Full, 43:Yellow_Full, 45:Green_Full, 47:Amber_Full
 state4value  = {0:0, 41:int(127*1/4), 43:int(127*2/4), 45:int(127*3/4), 47:int(127*4/4)}
 
 # it is preferred to use floating point control values between 0 and 1
-scalenote     = config.getfloat('scale', 'note')
-offsetnote    = config.getfloat('offset', 'note')
+scalenote     = patch.getfloat('scale', 'note')
+offsetnote    = patch.getfloat('offset', 'note')
 
 while True:
-    time.sleep(config.getfloat('general','delay'))
+    time.sleep(patch.getfloat('general','delay'))
 
     for msg in inputport.iter_pending():
         if midichannel is None:
@@ -186,7 +190,7 @@ while True:
 
         if hasattr(msg, "control"):
             # prefix.control000=value
-            key = "{}.control{:0>3d}".format(config.get('output', 'prefix'), msg.control)
+            key = "{}.control{:0>3d}".format(patch.get('output', 'prefix'), msg.control)
             val = msg.value
             r.set(key, val)
 
@@ -239,11 +243,11 @@ while True:
 
             if not val is None:
                 # prefix.noteXXX=value
-                key = "{}.note{:0>3d}".format(config.get('output','prefix'), msg.note)
+                key = "{}.note{:0>3d}".format(patch.get('output','prefix'), msg.note)
                 val = EEGsynth.rescale(val, slope=notescale, offset=noteoffset)
                 r.set(key, val)          # send it as control value
                 r.publish(key, val)      # send it as trigger
                 # prefix.note=note
-                key = "{}.note".format(config.get('output','prefix'))
+                key = "{}.note".format(patch.get('output','prefix'))
                 r.set(key, msg.note)          # send it as control value
                 r.publish(key, msg.note)      # send it as trigger

--- a/module/normalizecontrol/normalizecontrol.py
+++ b/module/normalizecontrol/normalizecontrol.py
@@ -56,20 +56,19 @@ import FieldTrip
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
+
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
-
-# this determines how much debugging information gets printed
-debug = config.getint('general', 'debug')
 
 try:
     r = redis.StrictRedis(host=config.get('redis',  'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
-    if debug > 0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general', 'debug')
 
 # read ini file
 inputlist = config.get('input', 'channels').split(",")
@@ -139,4 +138,3 @@ while True:
         # output min/max to redis, appended to input keys
         key = (inputlist[iinput] + '.norm')
         r.set(key, calibhistory[iinput, historysize-1])
-

--- a/module/normalizecontrol/normalizecontrol.py
+++ b/module/normalizecontrol/normalizecontrol.py
@@ -67,32 +67,36 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general', 'debug')
 
-# read ini file
-inputlist = config.get('input', 'channels').split(",")
-input_nrs = int(len(inputlist))
-stepsize = config.getfloat('general', 'stepsize')
-historysize = int(config.getfloat('general', 'window') / stepsize)
-learning_rate = config.getfloat('general', 'learning_rate')
-secwindow = config.getfloat('general', 'window')
-outputminmax = config.getint('general', 'outputminmax')
+# read configuration settings
+inputlist       = config.get('input', 'channels').split(",")
+input_nrs       = int(len(inputlist))
+stepsize        = config.getfloat('general', 'stepsize')
+historysize     = int(config.getfloat('general', 'window') / stepsize)
+learning_rate   = config.getfloat('general', 'learning_rate')
+secwindow       = config.getfloat('general', 'window')
+outputminmax    = config.getint('general', 'outputminmax')
 
 # Initialize variables
-inputhistory = np.ones((input_nrs, historysize))
-calibhistory = np.ones((input_nrs, historysize))
-inputmin = np.ones((input_nrs, historysize))
-inputmax = np.ones((input_nrs, historysize))
-inputminadd = np.ones((input_nrs, historysize))
-inputmaxadd = np.ones((input_nrs, historysize))
+inputhistory    = np.ones((input_nrs, historysize))
+calibhistory    = np.ones((input_nrs, historysize))
+inputmin        = np.ones((input_nrs, historysize))
+inputmax        = np.ones((input_nrs, historysize))
+inputminadd     = np.ones((input_nrs, historysize))
+inputmaxadd     = np.ones((input_nrs, historysize))
 
 while True:
    time.sleep(config.getfloat('general', 'delay'))
 
-   gain_att = EEGsynth.getfloat('attenuation', 'value', config, r, default=0.5)
-   gain_att = gain_att + EEGsynth.getfloat('attenuation', 'offset', config, r, default=0)
-   gain_att = gain_att * EEGsynth.getfloat('attenuation', 'scaling', config, r, default=1)
+   gain_att = patch.getfloat('attenuation', 'value', default=0.5)
+   gain_att = gain_att + patch.getfloat('attenuation', 'offset', default=0)
+   gain_att = gain_att * patch.getfloat('attenuation', 'scaling', default=1)
    if gain_att < 0.0:
         gain_att = 0
 

--- a/module/normalizecontrol/normalizecontrol.py
+++ b/module/normalizecontrol/normalizecontrol.py
@@ -61,7 +61,7 @@ config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
 try:
-    r = redis.StrictRedis(host=config.get('redis',  'hostname'), port=config.getint('redis', 'port'), db=0)
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
@@ -72,16 +72,16 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general', 'debug')
+debug = patch.getint('general', 'debug')
 
 # read configuration settings
-inputlist       = config.get('input', 'channels').split(",")
+inputlist       = patch.getstring('input', 'channels').split(",")
 input_nrs       = int(len(inputlist))
-stepsize        = config.getfloat('general', 'stepsize')
-historysize     = int(config.getfloat('general', 'window') / stepsize)
-learning_rate   = config.getfloat('general', 'learning_rate')
-secwindow       = config.getfloat('general', 'window')
-outputminmax    = config.getint('general', 'outputminmax')
+stepsize        = patch.getfloat('general', 'stepsize')
+historysize     = int(patch.getfloat('general', 'window') / stepsize)
+learning_rate   = patch.getfloat('general', 'learning_rate')
+secwindow       = patch.getfloat('general', 'window')
+outputminmax    = patch.getint('general', 'outputminmax')
 
 # Initialize variables
 inputhistory    = np.ones((input_nrs, historysize))
@@ -92,7 +92,7 @@ inputminadd     = np.ones((input_nrs, historysize))
 inputmaxadd     = np.ones((input_nrs, historysize))
 
 while True:
-   time.sleep(config.getfloat('general', 'delay'))
+   time.sleep(patch.getfloat('general', 'delay'))
 
    gain_att = patch.getfloat('attenuation', 'value', default=0.5)
    gain_att = gain_att + patch.getfloat('attenuation', 'offset', default=0)

--- a/module/outputartnet/outputartnet.py
+++ b/module/outputartnet/outputartnet.py
@@ -59,11 +59,11 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # prepare the data for a single universe
-address = [0, 0, config.getint('artnet','universe')]
-artnet = ArtNet.ArtNet(ip=config.get('artnet','broadcast'), port=config.getint('artnet','port'))
+address = [0, 0, patch.getint('artnet','universe')]
+artnet = ArtNet.ArtNet(ip=patch.getstring('artnet','broadcast'), port=patch.getint('artnet','port'))
 
 # blank out
 dmxdata = [0] * 512
@@ -74,7 +74,7 @@ prevtime = time.time()
 
 try:
     while True:
-        time.sleep(config.getfloat('general', 'delay'))
+        time.sleep(patch.getfloat('general', 'delay'))
 
         for chanindx in range(1, 256):
             chanstr = "channel%03d" % chanindx

--- a/module/outputartnet/outputartnet.py
+++ b/module/outputartnet/outputartnet.py
@@ -47,17 +47,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 # prepare the data for a single universe
 address = [0, 0, config.getint('artnet','universe')]

--- a/module/outputartnet/outputartnet.py
+++ b/module/outputartnet/outputartnet.py
@@ -54,6 +54,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -76,7 +80,7 @@ try:
             chanstr = "channel%03d" % chanindx
 
             try:
-                chanval = EEGsynth.getfloat('input', chanstr, config, r)
+                chanval = patch.getfloat('input', chanstr)
             except:
                 # the channel is not configured in the ini file, skip it
                 continue
@@ -85,10 +89,10 @@ try:
                 # the value is not present in redis, skip it
                 continue
 
-            if EEGsynth.getint('compressor_expander', 'enable', config, r):
+            if patch.getint('compressor_expander', 'enable'):
                 # the compressor applies to all channels and must exist as float or redis key
-                lo = EEGsynth.getfloat('compressor_expander', 'lo', config, r)
-                hi = EEGsynth.getfloat('compressor_expander', 'hi', config, r)
+                lo = patch.getfloat('compressor_expander', 'lo')
+                hi = patch.getfloat('compressor_expander', 'hi')
                 if lo is None or hi is None:
                     if debug>1:
                         print "cannot apply compressor/expander"
@@ -97,9 +101,9 @@ try:
                     chanval = EEGsynth.compress(chanval, lo, hi)
 
             # the scale option is channel specific
-            scale = EEGsynth.getfloat('scale', chanstr, config, r, default=1)
+            scale = patch.getfloat('scale', chanstr, default=1)
             # the offset option is channel specific
-            offset = EEGsynth.getfloat('offset', chanstr, config, r, default=0)
+            offset = patch.getfloat('offset', chanstr, default=0)
             # apply the scale and offset
             chanval = EEGsynth.rescale(chanval, slope=scale, offset=offset)
             chanval = int(chanval)

--- a/module/outputcvgate/outputcvgate.py
+++ b/module/outputcvgate/outputcvgate.py
@@ -58,10 +58,10 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 try:
-    s = serial.Serial(config.get('serial','device'), config.getint('serial','baudrate'), timeout=3.0)
+    s = serial.Serial(patch.getstring('serial','device'), patch.getint('serial','baudrate'), timeout=3.0)
     if debug>0:
         print "Connected to serial port"
 except:
@@ -69,7 +69,7 @@ except:
     exit()
 
 while True:
-    time.sleep(config.getfloat('general','delay'))
+    time.sleep(patch.getfloat('general','delay'))
 
     for chanindx in range(1, 8):
         chanstr = "cv%d" % chanindx

--- a/module/outputcvgate/outputcvgate.py
+++ b/module/outputcvgate/outputcvgate.py
@@ -46,17 +46,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 try:
     s = serial.Serial(config.get('serial','device'), config.getint('serial','baudrate'), timeout=3.0)

--- a/module/outputdmx512/outputdmx512.py
+++ b/module/outputdmx512/outputdmx512.py
@@ -53,6 +53,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -143,7 +147,7 @@ try:
             chanstr = "channel%03d" % chanindx
 
             try:
-                chanval = EEGsynth.getfloat('input', chanstr, config, r)
+                chanval = patch.getfloat('input', chanstr)
             except:
                 # the channel is not configured in the ini file, skip it
                 continue
@@ -152,10 +156,10 @@ try:
                 # the value is not present in redis, skip it
                 continue
 
-            if EEGsynth.getint('compressor_expander', 'enable', config, r):
+            if patch.getint('compressor_expander', 'enable'):
                 # the compressor applies to all channels and must exist as float or redis key
-                lo = EEGsynth.getfloat('compressor_expander', 'lo', config, r)
-                hi = EEGsynth.getfloat('compressor_expander', 'hi', config, r)
+                lo = patch.getfloat('compressor_expander', 'lo')
+                hi = patch.getfloat('compressor_expander', 'hi')
                 if lo is None or hi is None:
                     if debug>1:
                         print "cannot apply compressor/expander"
@@ -164,9 +168,9 @@ try:
                     chanval = EEGsynth.compress(chanval, lo, hi)
 
             # the scale option is channel specific
-            scale = EEGsynth.getfloat('scale', chanstr, config, r, default=1)
+            scale = patch.getfloat('scale', chanstr, default=1)
             # the offset option is channel specific
-            offset = EEGsynth.getfloat('offset', chanstr, config, r, default=0)
+            offset = patch.getfloat('offset', chanstr, default=0)
             # apply the scale and offset
             chanval = EEGsynth.rescale(chanval, slope=scale, offset=offset)
             chanval = int(chanval)

--- a/module/outputdmx512/outputdmx512.py
+++ b/module/outputdmx512/outputdmx512.py
@@ -58,12 +58,12 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 try:
     s = serial.Serial()
-    s.port=config.get('serial','device')
-    s.baudrate=config.get('serial','baudrate')
+    s.port=patch.getstring('serial','device')
+    s.baudrate=patch.getstring('serial','baudrate')
     s.bytesize=8
     s.parity='N'
     s.stopbits=2
@@ -141,7 +141,7 @@ prevtime = time.time()
 
 try:
     while True:
-        time.sleep(config.getfloat('general', 'delay'))
+        time.sleep(patch.getfloat('general', 'delay'))
 
         for chanindx in range(1, 512):
             chanstr = "channel%03d" % chanindx

--- a/module/outputdmx512/outputdmx512.py
+++ b/module/outputdmx512/outputdmx512.py
@@ -46,17 +46,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 try:
     s = serial.Serial()

--- a/module/outputosc/outputosc.py
+++ b/module/outputosc/outputosc.py
@@ -46,17 +46,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 try:
     s = OSC.OSCClient()

--- a/module/outputosc/outputosc.py
+++ b/module/outputosc/outputosc.py
@@ -58,11 +58,11 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 try:
     s = OSC.OSCClient()
-    s.connect((config.get('osc','hostname'), config.getint('osc','port')))
+    s.connect((patch.getstring('osc','hostname'), patch.getint('osc','port')))
     if debug>0:
         print "Connected to OSC server"
 except:
@@ -84,7 +84,7 @@ for i in range(len(list_input)):
             list3.append(list_output[j][1])
 
 while True:
-    time.sleep(config.getfloat('general', 'delay'))
+    time.sleep(patch.getfloat('general', 'delay'))
 
     for key1,key2,key3 in zip(list1,list2,list3):
 

--- a/module/playbackctrl/playbackctrl.py
+++ b/module/playbackctrl/playbackctrl.py
@@ -40,13 +40,13 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 if debug>0:
-    print "Reading data from", config.get('playback', 'file')
+    print "Reading data from", patch.getstring('playback', 'file')
 
 f = EDF.EDFReader()
-f.open(config.get('playback', 'file'))
+f.open(patch.getstring('playback', 'file'))
 
 if debug>1:
     print "NSignals", f.getNSignals()

--- a/module/playbackctrl/playbackctrl.py
+++ b/module/playbackctrl/playbackctrl.py
@@ -35,6 +35,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -86,7 +90,7 @@ while True:
         block     = 0
         continue
 
-    if EEGsynth.getint('playback', 'rewind', config, r):
+    if patch.getint('playback', 'rewind'):
         if debug>0:
             print "Rewind pressed, jumping back to start of file"
         begsample = 0
@@ -94,7 +98,7 @@ while True:
         block     = 0
         continue
 
-    if not EEGsynth.getint('playback', 'play', config, r):
+    if not patch.getint('playback', 'play'):
         if debug>0:
             print "Paused"
         time.sleep(0.1);
@@ -115,7 +119,7 @@ while True:
 
     # this is a short-term approach, estimating the sleep for every block
     # this code is shared between generatesignal, playback and playbackctrl
-    desired = blocksize/(fSample*EEGsynth.getfloat('playback', 'speed', config, r))
+    desired = blocksize/(fSample*patch.getfloat('playback', 'speed'))
     elapsed = time.time()-start
     naptime = desired - elapsed
     if naptime>0:

--- a/module/playbackctrl/playbackctrl.py
+++ b/module/playbackctrl/playbackctrl.py
@@ -28,17 +28,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 if debug>0:
     print "Reading data from", config.get('playback', 'file')

--- a/module/playbacksignal/playbacksignal.py
+++ b/module/playbacksignal/playbacksignal.py
@@ -50,17 +50,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 try:
     ftc_host = config.get('fieldtrip','hostname')

--- a/module/playbacksignal/playbacksignal.py
+++ b/module/playbacksignal/playbacksignal.py
@@ -62,11 +62,11 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 try:
-    ftc_host = config.get('fieldtrip','hostname')
-    ftc_port = config.getint('fieldtrip','port')
+    ftc_host = patch.getstring('fieldtrip','hostname')
+    ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
         print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
     ftc = FieldTrip.Client()
@@ -78,14 +78,14 @@ except:
     exit()
 
 try:
-    fileformat = config.get('playback', 'format')
+    fileformat = patch.getstring('playback', 'format')
 except:
-    fname = config.get('playback', 'file')
+    fname = patch.getstring('playback', 'file')
     name, ext = os.path.splitext(fname)
     fileformat = ext[1:]
 
 if debug>0:
-    print "Reading data from", config.get('playback', 'file')
+    print "Reading data from", patch.getstring('playback', 'file')
 
 H = FieldTrip.Header()
 
@@ -98,7 +98,7 @@ MAXINT32 =  np.power(2,31)-1
 
 if fileformat=='edf':
     f = EDF.EDFReader()
-    f.open(config.get('playback', 'file'))
+    f.open(patch.getstring('playback', 'file'))
     for chanindx in range(f.getNSignals()):
         if f.getSignalFreqs()[chanindx]!=f.getSignalFreqs()[0]:
             raise AssertionError('unequal SignalFreqs')
@@ -119,14 +119,14 @@ if fileformat=='edf':
 
 elif fileformat=='wav':
     try:
-        physical_min = config.getfloat('playback', 'physical_min')
+        physical_min = patch.getfloat('playback', 'physical_min')
     except:
         physical_min = -1
     try:
-        physical_max = config.getfloat('playback', 'physical_max')
+        physical_max = patch.getfloat('playback', 'physical_max')
     except:
         physical_max =  1
-    f = wave.open(config.get('playback', 'file'), 'r')
+    f = wave.open(patch.getstring('playback', 'file'), 'r')
     resolution = f.getsampwidth() # 1, 2 or 4
     # 8-bit samples are stored as unsigned bytes, ranging from 0 to 255.
     # 16-bit samples are stored as signed integers in 2's-complement.
@@ -164,7 +164,7 @@ if debug>1:
 
 ftc.putHeader(H.nChannels, H.fSample, H.dataType, labels=labels)
 
-blocksize = int(config.getfloat('playback', 'blocksize')*H.fSample)
+blocksize = int(patch.getfloat('playback', 'blocksize')*H.fSample)
 begsample = 0
 endsample = blocksize-1
 block     = 0

--- a/module/playbacksignal/playbacksignal.py
+++ b/module/playbacksignal/playbacksignal.py
@@ -57,6 +57,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -176,7 +180,7 @@ while True:
         block     = 0
         continue
 
-    if EEGsynth.getint('playback', 'rewind', config, r):
+    if patch.getint('playback', 'rewind'):
         if debug>0:
             print "Rewind pressed, jumping back to start of file"
         begsample = 0
@@ -184,7 +188,7 @@ while True:
         block     = 0
         continue
 
-    if not EEGsynth.getint('playback', 'play', config, r):
+    if not patch.getint('playback', 'play'):
         if debug>0:
             print "Paused"
         time.sleep(0.1);
@@ -208,7 +212,7 @@ while True:
 
     # this is a short-term approach, estimating the sleep for every block
     # this code is shared between generatesignal, playback and playbackctrl
-    desired = blocksize/(H.fSample*EEGsynth.getfloat('playback', 'speed', config, r))
+    desired = blocksize/(H.fSample*patch.getfloat('playback', 'speed'))
     elapsed = time.time()-start
     naptime = desired - elapsed
     if naptime>0:

--- a/module/plotcontrol/plotcontrol.py
+++ b/module/plotcontrol/plotcontrol.py
@@ -53,7 +53,7 @@ config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
 try:
-    r = redis.StrictRedis(host=config.get('redis',  'hostname'), port=config.getint('redis', 'port'), db=0)
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
@@ -64,7 +64,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general', 'debug')
+debug = patch.getint('general', 'debug')
 
 input_name, input_variable = zip(*config.items('input'))
 
@@ -76,9 +76,9 @@ for i in range(len(input_name)):
         curve_nrs += 1
 
 ylim_name, ylim_value = zip(*config.items('ylim'))
-delay = config.getfloat('general', 'delay')
-historysize = int(config.getfloat('general', 'window') / delay)
-secwindow = config.getfloat('general', 'window')
+delay = patch.getfloat('general', 'delay')
+historysize = int(patch.getfloat('general', 'window') / delay)
+secwindow = patch.getfloat('general', 'window')
 
 # initialize graphical window
 app = QtGui.QApplication([])

--- a/module/plotcontrol/plotcontrol.py
+++ b/module/plotcontrol/plotcontrol.py
@@ -59,6 +59,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general', 'debug')
 

--- a/module/plotcontrol/plotcontrol.py
+++ b/module/plotcontrol/plotcontrol.py
@@ -52,17 +52,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general', 'debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis',  'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general', 'debug')
 
 input_name, input_variable = zip(*config.items('input'))
 

--- a/module/plotsignal/plotsignal.py
+++ b/module/plotsignal/plotsignal.py
@@ -67,7 +67,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 def butter_bandpass(lowcut, highcut, fs, order=9):
     nyq = 0.5 * fs
@@ -93,8 +93,8 @@ def butter_lowpass_filter(data, lowcut, fs, order=9):
     return y
 
 try:
-    ftc_host = config.get('fieldtrip','hostname')
-    ftc_port = config.getint('fieldtrip','port')
+    ftc_host = patch.getstring('fieldtrip','hostname')
+    ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
         print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
     ft_input = FieldTrip.Client()
@@ -114,23 +114,23 @@ while hdr_input is None:
 
 print "Data arrived"
 
-chanlist = config.get('arguments','channels').split(",")
+chanlist = patch.getstring('arguments','channels').split(",")
 chanarray = np.array(chanlist)
 for i in range(len(chanarray)):
     chanarray[i] = int(chanarray[i]) - 1 # since python using indexing from 0 instead of 1
 
 chan_nrs = len(chanlist)
 
-window     = config.getfloat('arguments','window')   # in seconds
+window     = patch.getfloat('arguments','window')   # in seconds
 window     = int(round(window*hdr_input.fSample))    # in samples
-clipsize   = config.getfloat('arguments','clipsize') # in seconds
+clipsize   = patch.getfloat('arguments','clipsize') # in seconds
 clipsize   = int(round(clipsize*hdr_input.fSample))  # in samples
-stepsize   = config.getfloat('arguments','stepsize') # in seconds
-lrate      = config.getfloat('arguments','learning_rate')
-scalered   = config.getfloat('scale','red')
-scaleblue  = config.getfloat('scale','blue')
-offsetred  = config.getfloat('offset','red')
-offsetblue = config.getfloat('offset','blue')
+stepsize   = patch.getfloat('arguments','stepsize') # in seconds
+lrate      = patch.getfloat('arguments','learning_rate')
+scalered   = patch.getfloat('scale','red')
+scaleblue  = patch.getfloat('scale','blue')
+offsetred  = patch.getfloat('offset','red')
+offsetblue = patch.getfloat('offset','blue')
 
 # initialize graphical window
 app = QtGui.QApplication([])
@@ -209,7 +209,7 @@ def update():
         freqaxis = fftfreq(len(data), 1/hdr_input.fSample)
 
         # user-selected frequency band
-        arguments_freqrange = config.get('arguments', 'freqrange').split("-")
+        arguments_freqrange = patch.getstring('arguments', 'freqrange').split("-")
         arguments_freqrange = [float(s) for s in arguments_freqrange]
         freqrange = np.greater(freqaxis, arguments_freqrange[0]) & np.less_equal(freqaxis, arguments_freqrange[1])
 
@@ -248,13 +248,13 @@ def update():
         blueleft[ichan].setData(x=[bluefreq-bluewidth,bluefreq-bluewidth],y=[specmin[ichan],specmax[ichan]])
         blueright[ichan].setData(x=[bluefreq+bluewidth,bluefreq+bluewidth],y=[specmin[ichan],specmax[ichan]])
 
-   key = "%s.%s.%s" % (config.get('output', 'prefix'), 'redband', 'low')
+   key = "%s.%s.%s" % (patch.getstring('output', 'prefix'), 'redband', 'low')
    r.set(key, [redfreq-redwidth])
-   key = "%s.%s.%s" % (config.get('output', 'prefix'), 'redband', 'high')
+   key = "%s.%s.%s" % (patch.getstring('output', 'prefix'), 'redband', 'high')
    r.set(key, [redfreq+redwidth])
-   key = "%s.%s.%s" % (config.get('output', 'prefix'), 'blueband', 'low')
+   key = "%s.%s.%s" % (patch.getstring('output', 'prefix'), 'blueband', 'low')
    r.set(key, [bluefreq-bluewidth])
-   key = "%s.%s.%s" % (config.get('output', 'prefix'), 'blueband', 'high')
+   key = "%s.%s.%s" % (patch.getstring('output', 'prefix'), 'blueband', 'high')
    r.set(key, [bluefreq+bluewidth])
 
 # Set timer for update

--- a/module/plotsignal/plotsignal.py
+++ b/module/plotsignal/plotsignal.py
@@ -62,6 +62,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -227,16 +231,16 @@ def update():
         freqplot[ichan].setYRange(specmin[ichan], specmax[ichan])
 
         # update plotted lines
-        redfreq = EEGsynth.getfloat('input', 'redfreq', config, r, default=10./arguments_freqrange[1])
+        redfreq = patch.getfloat('input', 'redfreq', default=10./arguments_freqrange[1])
         redfreq = EEGsynth.rescale(redfreq, slope=scalered, offset=offsetred) * arguments_freqrange[1]
 
-        redwidth = EEGsynth.getfloat('input', 'redwidth', config, r, default=1./arguments_freqrange[1])
+        redwidth = patch.getfloat('input', 'redwidth', default=1./arguments_freqrange[1])
         redwidth = EEGsynth.rescale(redwidth, slope=scalered, offset=offsetred) * arguments_freqrange[1]
 
-        bluefreq = EEGsynth.getfloat('input', 'bluefreq', config, r, default=20./arguments_freqrange[1])
+        bluefreq = patch.getfloat('input', 'bluefreq', default=20./arguments_freqrange[1])
         bluefreq = EEGsynth.rescale(bluefreq, slope=scaleblue, offset=offsetblue) * arguments_freqrange[1]
 
-        bluewidth = EEGsynth.getfloat('input', 'bluewidth', config, r, default=4./arguments_freqrange[1])
+        bluewidth = patch.getfloat('input', 'bluewidth', default=4./arguments_freqrange[1])
         bluewidth = EEGsynth.rescale(bluewidth, slope=scaleblue, offset=offsetblue) * arguments_freqrange[1]
 
         redleft[ichan].setData(x=[redfreq-redwidth,redfreq-redwidth],y=[specmin[ichan],specmax[ichan]])

--- a/module/plotsignal/plotsignal.py
+++ b/module/plotsignal/plotsignal.py
@@ -55,6 +55,13 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+try:
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print "Error: cannot connect to redis server"
+    exit()
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -102,15 +109,6 @@ while hdr_input is None:
     time.sleep(0.2)
 
 print "Data arrived"
-
-try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
-    response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
-except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
-    exit()
 
 chanlist = config.get('arguments','channels').split(",")
 chanarray = np.array(chanlist)

--- a/module/postprocessing/postprocessing.py
+++ b/module/postprocessing/postprocessing.py
@@ -50,17 +50,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 # get the input and output options
 input_name, input_variable = zip(*config.items('input'))

--- a/module/postprocessing/postprocessing.py
+++ b/module/postprocessing/postprocessing.py
@@ -57,6 +57,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -92,7 +96,7 @@ while True:
 
     actual_value = [];
     for name in input_name:
-        actual_value.append(EEGsynth.getfloat('input', name, config, r))
+        actual_value.append(patch.getfloat('input', name))
 
     for key,equation in zip(output_name, output_equation):
         for name,value in zip(input_name, actual_value):

--- a/module/postprocessing/postprocessing.py
+++ b/module/postprocessing/postprocessing.py
@@ -62,7 +62,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # get the input and output options
 input_name, input_variable = zip(*config.items('input'))
@@ -92,7 +92,7 @@ if debug>0:
 
 
 while True:
-    time.sleep(config.getfloat('general', 'delay'))
+    time.sleep(patch.getfloat('general', 'delay'))
 
     actual_value = [];
     for name in input_name:

--- a/module/preprocessing/preprocessing.py
+++ b/module/preprocessing/preprocessing.py
@@ -28,7 +28,6 @@ import ConfigParser # this is version 2.x specific, on version 3.x it is called 
 import argparse
 import numpy as np
 import os
-import redis
 import sys
 import time
 

--- a/module/preprocessing/preprocessing.py
+++ b/module/preprocessing/preprocessing.py
@@ -51,8 +51,13 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
+
 # this is the timeout for the FieldTrip buffer
 timeout = config.getfloat('input_fieldtrip','timeout')
 

--- a/module/quantizer/quantizer.py
+++ b/module/quantizer/quantizer.py
@@ -46,17 +46,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 # get the input and output options
 input_channel, input_name = map(list, zip(*config.items('input')))

--- a/module/quantizer/quantizer.py
+++ b/module/quantizer/quantizer.py
@@ -53,6 +53,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -62,7 +66,7 @@ quantized_name, quantized_value = map(list, zip(*config.items('quantization')))
 
 # get the list of values for each of the quantization levels
 for i,name in enumerate(quantized_name):
-    quantized_value[i] = EEGsynth.getfloat('quantization', name, config, r, multiple=True)
+    quantized_value[i] = patch.getfloat('quantization', name, multiple=True)
 
 # find the level to which the data is to be quantized
 index =  quantized_name.index('level')
@@ -80,7 +84,7 @@ while True:
     time.sleep(config.getfloat('general', 'delay'))
 
     for channel,name in zip(input_channel, input_name):
-        val = EEGsynth.getfloat('input', channel, config, r)
+        val = patch.getfloat('input', channel)
         if val is None:
             pass
         else:

--- a/module/quantizer/quantizer.py
+++ b/module/quantizer/quantizer.py
@@ -58,7 +58,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # get the input and output options
 input_channel, input_name = map(list, zip(*config.items('input')))
@@ -81,7 +81,7 @@ def find_nearest_idx(array,value):
     return idx
 
 while True:
-    time.sleep(config.getfloat('general', 'delay'))
+    time.sleep(patch.getfloat('general', 'delay'))
 
     for channel,name in zip(input_channel, input_name):
         val = patch.getfloat('input', channel)

--- a/module/recordctrl/recordctrl.py
+++ b/module/recordctrl/recordctrl.py
@@ -56,6 +56,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -68,19 +72,19 @@ while True:
     # measure the time to correct for the slip
     now = time.time()
 
-    if recording and not EEGsynth.getint('recording', 'record', config, r):
+    if recording and not patch.getint('recording', 'record'):
         if debug>0:
             print "Recording disabled - closing", fname
         f.close()
         recording = False
         continue
 
-    if not recording and not EEGsynth.getint('recording', 'record', config, r):
+    if not recording and not patch.getint('recording', 'record'):
         if debug>0:
             print "Recording is not enabled"
         time.sleep(1)
 
-    if not recording and EEGsynth.getint('recording', 'record', config, r):
+    if not recording and patch.getint('recording', 'record'):
         recording = True
         # open a new file
         fname = config.get('recording', 'file')

--- a/module/recordctrl/recordctrl.py
+++ b/module/recordctrl/recordctrl.py
@@ -61,11 +61,11 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 filenumber  = 0
 recording   = False
-delay       = config.getfloat('general','delay')
+delay       = patch.getfloat('general','delay')
 adjust      = 1
 
 while True:
@@ -87,7 +87,7 @@ while True:
     if not recording and patch.getint('recording', 'record'):
         recording = True
         # open a new file
-        fname = config.get('recording', 'file')
+        fname = patch.getstring('recording', 'file')
         name, ext = os.path.splitext(fname)
         fname = name + '_' + datetime.datetime.now().strftime("%Y.%m.%d_%H.%M.%S") + ext
         # get the details from REDIS

--- a/module/recordctrl/recordctrl.py
+++ b/module/recordctrl/recordctrl.py
@@ -49,17 +49,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 filenumber  = 0
 recording   = False

--- a/module/recordsignal/recordsignal.py
+++ b/module/recordsignal/recordsignal.py
@@ -56,19 +56,17 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+try:
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print "Error: cannot connect to redis server"
+    exit()
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 # this is the timeout for the FieldTrip buffer
 timeout = config.getfloat('fieldtrip','timeout')
-
-try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
-    response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
-except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
-    exit()
 
 try:
     ftc_host = config.get('fieldtrip','hostname')

--- a/module/recordsignal/recordsignal.py
+++ b/module/recordsignal/recordsignal.py
@@ -68,14 +68,14 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # this is the timeout for the FieldTrip buffer
-timeout = config.getfloat('fieldtrip','timeout')
+timeout = patch.getfloat('fieldtrip','timeout')
 
 try:
-    ftc_host = config.get('fieldtrip','hostname')
-    ftc_port = config.getint('fieldtrip','port')
+    ftc_host = patch.getstring('fieldtrip','hostname')
+    ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
         print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
     ftc = FieldTrip.Client()
@@ -103,13 +103,13 @@ if debug>1:
 
 recording = False
 
-physical_min = config.getfloat('recording', 'physical_min')
-physical_max = config.getfloat('recording', 'physical_max')
+physical_min = patch.getfloat('recording', 'physical_min')
+physical_max = patch.getfloat('recording', 'physical_max')
 
 try:
-    fileformat = config.get('recording', 'format')
+    fileformat = patch.getstring('recording', 'format')
 except:
-    fname = config.get('recording', 'file')
+    fname = patch.getstring('recording', 'file')
     name, ext = os.path.splitext(fname)
     fileformat = ext[1:]
 
@@ -138,13 +138,13 @@ while True:
     if not recording and patch.getint('recording', 'record'):
         recording = True
         # open a new file
-        fname = config.get('recording', 'file')
+        fname = patch.getstring('recording', 'file')
         name, ext = os.path.splitext(fname)
         if len(ext)==0:
             ext = '.' + fileformat
         fname = name + '_' + datetime.datetime.now().strftime("%Y.%m.%d_%H.%M.%S") + ext
         # the blocksize depends on the sampling rate, which may have changed
-        blocksize = int(config.getfloat('recording', 'blocksize')*hdr_input.fSample)
+        blocksize = int(patch.getfloat('recording', 'blocksize')*hdr_input.fSample)
         # write the header to file
         if debug>0:
             print "Opening", fname

--- a/module/recordsignal/recordsignal.py
+++ b/module/recordsignal/recordsignal.py
@@ -63,8 +63,13 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
+
 # this is the timeout for the FieldTrip buffer
 timeout = config.getfloat('fieldtrip','timeout')
 
@@ -118,19 +123,19 @@ while True:
         recording = False
         continue
 
-    if recording and not EEGsynth.getint('recording', 'record', config, r):
+    if recording and not patch.getint('recording', 'record'):
         if debug>0:
             print "Recording disabled - closing", fname
         f.close()
         recording = False
         continue
 
-    if not recording and not EEGsynth.getint('recording', 'record', config, r):
+    if not recording and not patch.getint('recording', 'record'):
         if debug>0:
             print "Recording is not enabled"
         time.sleep(1)
 
-    if not recording and EEGsynth.getint('recording', 'record', config, r):
+    if not recording and patch.getint('recording', 'record'):
         recording = True
         # open a new file
         fname = config.get('recording', 'file')

--- a/module/rms/rms.py
+++ b/module/rms/rms.py
@@ -58,8 +58,13 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
+
 # this is the timeout for the FieldTrip buffer
 timeout = config.getfloat('fieldtrip','timeout')
 

--- a/module/rms/rms.py
+++ b/module/rms/rms.py
@@ -51,19 +51,17 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+try:
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print "Error: cannot connect to redis server"
+    exit()
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 # this is the timeout for the FieldTrip buffer
 timeout = config.getfloat('fieldtrip','timeout')
-
-try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
-    response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
-except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
-    exit()
 
 try:
     ftc_host = config.get('fieldtrip','hostname')

--- a/module/sequencer/sequencer.ini
+++ b/module/sequencer/sequencer.ini
@@ -17,7 +17,7 @@ pattern7=  7   7   7   7
 pattern8=  8   8   8   8
 pattern9=  9   9   9   9
 
-[input]
+[control]
 pattern=launchcontrol.control013    ; one of the patterns listed above
 rate=launchcontrol.control014       ; in beats per minute
 transpose=launchcontrol.control015

--- a/module/sequencer/sequencer.py
+++ b/module/sequencer/sequencer.py
@@ -46,15 +46,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'),port=config.getint('redis','port'),db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 pattern = EEGsynth.getint('input','pattern', config, r, default=0)
 previous = pattern

--- a/module/sequencer/sequencer.py
+++ b/module/sequencer/sequencer.py
@@ -53,10 +53,14 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
-pattern = EEGsynth.getint('input','pattern', config, r, default=0)
+pattern = patch.getint('input','pattern', default=0)
 previous = pattern
 
 try:
@@ -73,11 +77,11 @@ try:
             note = int(note)
 
             # this will return empty if not available
-            pattern = EEGsynth.getint('input','pattern', config, r, default=0)
+            pattern = patch.getint('input','pattern', default=0)
 
             if pattern!=previous:
                 # get the corresponding sequence
-                pattern = EEGsynth.getint('input','pattern', config, r, default=0)
+                pattern = patch.getint('input','pattern', default=0)
                 try:
                   sequence = config.get('sequence',"pattern{:d}".format(pattern))
                 except:
@@ -88,12 +92,12 @@ try:
                 break
 
             # use a default rate of 90 bpm
-            rate = EEGsynth.getfloat('input','rate', config, r)
+            rate = patch.getfloat('input','rate')
             if rate is None:
                 rate = 90
 
             # use a default transposition of 48
-            transpose = EEGsynth.getint('input','transpose', config, r)
+            transpose = patch.getint('input','transpose')
             if transpose is None:
                 transpose = 48
 

--- a/module/sequencer/sequencer.py
+++ b/module/sequencer/sequencer.py
@@ -47,7 +47,7 @@ config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
 try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'),port=config.getint('redis','port'),db=0)
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
@@ -58,13 +58,13 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 pattern = patch.getint('input','pattern', default=0)
 previous = pattern
 
 try:
-  sequence = config.get('sequence',"pattern{:d}".format(pattern))
+  sequence = patch.getstring('sequence',"pattern{:d}".format(pattern))
 except:
   sequence = '0'
 
@@ -83,7 +83,7 @@ try:
                 # get the corresponding sequence
                 pattern = patch.getint('input','pattern', default=0)
                 try:
-                  sequence = config.get('sequence',"pattern{:d}".format(pattern))
+                  sequence = patch.getstring('sequence',"pattern{:d}".format(pattern))
                 except:
                   sequence = '0'
                 # immediately start playing the new sequence
@@ -108,7 +108,7 @@ try:
             if debug>0:
                 print pattern, rate, transpose, note
 
-            key = "{}.note".format(config.get('output','prefix'))
+            key = "{}.note".format(patch.getstring('output','prefix'))
             val = note + transpose
 
             r.set(key,val)      # send it as control value: prefix.channel000.note=note

--- a/module/sequencer/sequencer.py
+++ b/module/sequencer/sequencer.py
@@ -60,15 +60,37 @@ del config
 # this determines how much debugging information gets printed
 debug = patch.getint('general','debug')
 
-pattern = patch.getint('input','pattern', default=0)
+# assume that the control values are between 0 and 1
+scale_pattern   = patch.getfloat('scale', 'pattern',   default=127) # MIDI values
+scale_transpose = patch.getfloat('scale', 'transpose', default=127) # MIDI values
+scale_rate      = patch.getfloat('scale', 'rate',      default=127) # beats per minute
+
+offset_pattern   = patch.getfloat('offset', 'pattern',   default=0)
+offset_transpose = patch.getfloat('offset', 'transpose', default=0)
+offset_rate      = patch.getfloat('offset', 'rate',      default=0)
+
+if debug>0:
+    print 'scale_pattern', scale_pattern
+    print 'scale_transpose', scale_transpose
+    print 'scale_rate', scale_rate
+    print 'offset_pattern', offset_pattern
+    print 'offset_transpose', offset_transpose
+    print 'offset_rate', offset_rate
+
+# the pattern should be an integer between 0 and 127
+pattern = patch.getfloat('control','pattern', default=0)
+pattern = EEGsynth.rescale(pattern, slope=scale_pattern, offset=offset_pattern)
+pattern = int(pattern)
 previous = pattern
 
 try:
-  sequence = patch.getstring('sequence',"pattern{:d}".format(pattern))
+    sequence = patch.getstring('sequence',"pattern{:d}".format(pattern))
 except:
-  sequence = '0'
+    sequence = '0'
 
-print pattern, sequence
+if debug>0:
+    print 'pattern  =', pattern
+    print 'sequence =', sequence
 
 try:
     while True:
@@ -76,45 +98,52 @@ try:
         for note in sequence.split():
             note = int(note)
 
-            # this will return empty if not available
-            pattern = patch.getint('input','pattern', default=0)
+            # the pattern should be an integer between 0 and 127
+            pattern = patch.getfloat('control','pattern', default=0)
+            pattern = EEGsynth.rescale(pattern, slope=scale_pattern, offset=offset_pattern)
+            pattern = int(pattern)
 
             if pattern!=previous:
                 # get the corresponding sequence
-                pattern = patch.getint('input','pattern', default=0)
                 try:
-                  sequence = patch.getstring('sequence',"pattern{:d}".format(pattern))
+                    sequence = patch.getstring('sequence',"pattern{:d}".format(pattern))
                 except:
-                  sequence = '0'
+                    sequence = '0'
+
                 # immediately start playing the new sequence
                 previous = pattern
                 print 'break'
                 break
 
-            # use a default rate of 90 bpm
-            rate = patch.getfloat('input','rate')
-            if rate is None:
-                rate = 90
-
             # use a default transposition of 48
-            transpose = patch.getint('input','transpose')
-            if transpose is None:
-                transpose = 48
+            transpose = patch.getfloat('control','transpose', default=48./127)
+            transpose = EEGsynth.rescale(transpose, slope=scale_transpose, offset=offset_transpose)
 
-            # assume that the rate value is between 0 and 127, map it exponentially from 20 to 2000
+            # use a default rate of 90 bpm
+            rate = patch.getfloat('control','rate', default=90./127)
+            rate = EEGsynth.rescale(rate, slope=scale_rate, offset=offset_rate)
+
+            # assume that the rate value is between 0 and 127, map it exponentially from 60 to 600
             # it should not get too low, otherwise the code with the sleep below becomes unresponsive
-            rate = 20*math.exp(rate*math.log(100)/127)
+            rate = 60. * math.exp(math.log(10) * rate/127)
 
             if debug>0:
-                print pattern, rate, transpose, note
+                print '-----------------------'
+                print 'pattern   =', pattern
+                print 'rate      =', rate
+                print 'transpose =', transpose
+                print 'note      =', note
 
             key = "{}.note".format(patch.getstring('output','prefix'))
             val = note + transpose
 
+            if debug>0:
+                print 'sending', key, 'with value', val
+
             r.set(key,val)      # send it as control value: prefix.channel000.note=note
             r.publish(key,val)  # send it as trigger: prefix.channel000.note=note
 
-            time.sleep(60/rate)
+            time.sleep(60./rate)
 
 except KeyboardInterrupt:
     try:

--- a/module/smoothing/smoothing.py
+++ b/module/smoothing/smoothing.py
@@ -50,17 +50,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 # see https://en.wikipedia.org/wiki/Median_absolute_deviation
 def mad(arr, axis=None):

--- a/module/smoothing/smoothing.py
+++ b/module/smoothing/smoothing.py
@@ -57,6 +57,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 

--- a/module/smoothing/smoothing.py
+++ b/module/smoothing/smoothing.py
@@ -62,7 +62,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # see https://en.wikipedia.org/wiki/Median_absolute_deviation
 def mad(arr, axis=None):
@@ -72,10 +72,10 @@ def mad(arr, axis=None):
         val = np.nanmedian(np.abs(arr - np.nanmedian(arr)))
     return val
 
-prefix      = config.get('output','prefix')
-inputlist   = config.get('input','channels').split(",")
-stepsize    = config.getfloat('smoothing','stepsize')   # in seconds
-window      = config.getfloat('smoothing','window')     # in seconds
+prefix      = patch.getstring('output','prefix')
+inputlist   = patch.getstring('input','channels').split(",")
+stepsize    = patch.getfloat('smoothing','stepsize')   # in seconds
+window      = patch.getfloat('smoothing','window')     # in seconds
 numchannel  = len(inputlist)
 numhistory  = int(round(window/stepsize))
 

--- a/module/spectral/spectral.py
+++ b/module/spectral/spectral.py
@@ -63,14 +63,14 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # this is the timeout for the FieldTrip buffer
-timeout = config.getfloat('fieldtrip', 'timeout')
+timeout = patch.getfloat('fieldtrip', 'timeout')
 
 try:
-    ftc_host = config.get('fieldtrip','hostname')
-    ftc_port = config.getint('fieldtrip','port')
+    ftc_host = patch.getstring('fieldtrip','hostname')
+    ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
         print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
     ftc = FieldTrip.Client()
@@ -97,17 +97,17 @@ class TriggerThread(threading.Thread):
         self.running = False
     def run(self):
         pubsub = self.r.pubsub()
-        pubsub.subscribe(self.config.get('gain_control','recalibrate'))
-        pubsub.subscribe(self.config.get('gain_control','freeze'))
-        pubsub.subscribe(self.config.get('gain_control','increase'))
-        pubsub.subscribe(self.config.get('gain_control','decrease'))
+        pubsub.subscribe(self.patch.getstring('gain_control','recalibrate'))
+        pubsub.subscribe(self.patch.getstring('gain_control','freeze'))
+        pubsub.subscribe(self.patch.getstring('gain_control','increase'))
+        pubsub.subscribe(self.patch.getstring('gain_control','decrease'))
         pubsub.subscribe('BRAIN_UNBLOCK')  # this message unblocks the redis listen command
         while self.running:
             for item in pubsub.listen():
                 if not self.running or not item['type'] == 'message':
                     break
                 lock.acquire()
-                if item['channel']==self.config.get('gain_control','recalibrate'):
+                if item['channel']==self.patch.getstring('gain_control','recalibrate'):
                     if not self.freeze:
                         # this will cause the min/max values to be completely reset
                         self.minval = None
@@ -116,7 +116,7 @@ class TriggerThread(threading.Thread):
                             print 'recalibrate', self.minval, self.maxval
                     else:
                         print 'not recalibrating, freeze is on'
-                elif item['channel']==self.config.get('gain_control','freeze'):
+                elif item['channel']==self.patch.getstring('gain_control','freeze'):
                     # freeze the automatic adjustment of the gain control
                     # when frozen, the recalibrate should also not be done
                     self.freeze = (int(item['data'])>0)
@@ -125,24 +125,24 @@ class TriggerThread(threading.Thread):
                             print 'freeze on'
                         else:
                             print 'freeze off'
-                elif item['channel']==self.config.get('gain_control','increase'):
+                elif item['channel']==self.patch.getstring('gain_control','increase'):
                     # decreasing the min/max values will increase the gain
                     if not self.minval is None:
                         for i, (min, max) in enumerate(zip(self.minval, self.maxval)):
                             range = float(max-min)
                             if range>0:
-                                self.minval[i] += range * self.config.getfloat('gain_control','stepsize')
-                                self.maxval[i] -= range * self.config.getfloat('gain_control','stepsize')
+                                self.minval[i] += range * self.patch.getfloat('gain_control','stepsize')
+                                self.maxval[i] -= range * self.patch.getfloat('gain_control','stepsize')
                     if debug>0:
                         print 'increase', self.minval, self.maxval
-                elif item['channel']==self.config.get('gain_control','decrease'):
+                elif item['channel']==self.patch.getstring('gain_control','decrease'):
                     # increasing the min/max values will decrease the gain
                     if not self.minval is None:
                         for i, (min, max) in enumerate(zip(self.minval, self.maxval)):
                             range = float(max-min)
                             if range>0:
-                                self.minval[i] -= range * self.config.getfloat('gain_control','stepsize')
-                                self.maxval[i] += range * self.config.getfloat('gain_control','stepsize')
+                                self.minval[i] -= range * self.patch.getfloat('gain_control','stepsize')
+                                self.maxval[i] += range * self.patch.getfloat('gain_control','stepsize')
                     if debug>0:
                         print 'decrease', self.minval, self.maxval
                 self.update = True
@@ -175,12 +175,12 @@ try:
     for item in channel_items:
         # channel numbers are one-offset in the ini file, zero-offset in the code
         channame.append(item[0])
-        chanindx.append(config.getint('input', item[0])-1)
+        chanindx.append(patch.getint('input', item[0])-1)
 
     if debug>0:
         print channame, chanindx
 
-    window = int(round(config.getfloat('processing','window') * hdr_input.fSample))
+    window = int(round(patch.getfloat('processing','window') * hdr_input.fSample))
     minval = None
     maxval = None
     freeze = False
@@ -196,7 +196,7 @@ try:
     endsample = -1
 
     while True:
-        time.sleep(config.getfloat('general','delay'))
+        time.sleep(patch.getfloat('general','delay'))
 
         band_items = config.items('band')
         bandname = []
@@ -207,7 +207,7 @@ try:
             lohi = patch.getfloat('band', item[0], multiple=True)
             if debug>2:
                 print item[0], lohi
-            # lohi = config.get('band', item[0]).split("-")
+            # lohi = patch.getstring('band', item[0]).split("-")
             bandname.append(item[0])
             bandlo.append(lohi[0])
             bandhi.append(lohi[1])
@@ -290,7 +290,7 @@ try:
         for chan in channame:
             for band in bandname:
                 # send the control value prefix.channel.band=value
-                key = "%s.%s.%s" % (config.get('output','prefix'), chan, band)
+                key = "%s.%s.%s" % (patch.getstring('output','prefix'), chan, band)
                 val = int(127.0*power[i])
                 r.set(key,val)
                 i+=1

--- a/module/spectral/spectral.py
+++ b/module/spectral/spectral.py
@@ -58,8 +58,13 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
+
 # this is the timeout for the FieldTrip buffer
 timeout = config.getfloat('fieldtrip', 'timeout')
 
@@ -199,7 +204,7 @@ try:
         bandhi   = []
         for item in band_items:
             # channel numbers are one-offset in the ini file, zero-offset in the code
-            lohi = EEGsynth.getfloat('band', item[0], config, r, multiple=True)
+            lohi = patch.getfloat('band', item[0], multiple=True)
             if debug>2:
                 print item[0], lohi
             # lohi = config.get('band', item[0]).split("-")

--- a/module/spectral/spectral.py
+++ b/module/spectral/spectral.py
@@ -51,19 +51,17 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+try:
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print "Error: cannot connect to redis server"
+    exit()
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 # this is the timeout for the FieldTrip buffer
 timeout = config.getfloat('fieldtrip', 'timeout')
-
-try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
-    response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
-except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
-    exit()
 
 try:
     ftc_host = config.get('fieldtrip','hostname')

--- a/module/synchronization/synchronization.py
+++ b/module/synchronization/synchronization.py
@@ -49,15 +49,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 serialport = None
 def initialize_serial():

--- a/module/synchronization/synchronization.py
+++ b/module/synchronization/synchronization.py
@@ -61,12 +61,12 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 serialport = None
 def initialize_serial():
     try:
-        serialport = serial.Serial(config.get('serial','device'), config.getint('serial','baudrate'), timeout=3.0)
+        serialport = serial.Serial(patch.getstring('serial','device'), patch.getint('serial','baudrate'), timeout=3.0)
     except:
         print "Error: cannot connect to serial output"
         exit()
@@ -104,7 +104,7 @@ class MidiThread(threading.Thread):
             print msg
         while self.running:
             if not self.enabled:
-                time.sleep(config.getfloat('general', 'delay'))
+                time.sleep(patch.getfloat('general', 'delay'))
             else:
                 now = time.time()
                 delay = 60/self.rate      # the rate is in bpm
@@ -128,10 +128,10 @@ slip            = 0
 tick            = 0
 adjust_offset   = 0
 previous_offset = 0
-pulselength = config.getfloat('general','pulselength')
+pulselength = patch.getfloat('general','pulselength')
 
 # this is how it will appear in REDIS
-key = "%s.%s" % (config.get('output','prefix'), config.get('input','rate'))
+key = "%s.%s" % (patch.getstring('output','prefix'), patch.getstring('input','rate'))
 
 # these will only be started when needed
 init_midi   = False
@@ -178,7 +178,7 @@ try:
 
         rate = patch.getfloat('input', 'rate')
         if rate is None:
-            time.sleep(config.getfloat('general', 'delay'))
+            time.sleep(patch.getfloat('general', 'delay'))
             continue
 
         offset = patch.getfloat('input', 'offset', default=64)

--- a/module/synchronization/synchronization.py
+++ b/module/synchronization/synchronization.py
@@ -56,6 +56,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -145,9 +149,9 @@ try:
         # measure the time to correct for the slip
         now = time.time()
 
-        use_serial = EEGsynth.getint('general', 'serial', config, r, default=0)
-        use_midi   = EEGsynth.getint('general', 'midi', config, r, default=0)
-        use_redis  = EEGsynth.getint('general', 'redis', config, r, default=0)
+        use_serial = patch.getint('general', 'serial', default=0)
+        use_midi   = patch.getint('general', 'midi', default=0)
+        use_redis  = patch.getint('general', 'redis', default=0)
 
         if previous_use_serial is None:
             previous_use_serial = not(use_serial);
@@ -172,16 +176,16 @@ try:
             midisync.disable()
             previous_use_midi = False
 
-        rate = EEGsynth.getfloat('input', 'rate', config, r)
+        rate = patch.getfloat('input', 'rate')
         if rate is None:
             time.sleep(config.getfloat('general', 'delay'))
             continue
 
-        offset = EEGsynth.getfloat('input', 'offset', config, r, default=64)
+        offset = patch.getfloat('input', 'offset', default=64)
         # the offset value from 0-127 gets scaled to a value from -1 to +1 seconds
         offset = (offset-64)/(127/2)
 
-        multiplier = EEGsynth.getfloat('input', 'multiplier', config, r, default=1)
+        multiplier = patch.getfloat('input', 'multiplier', default=1)
         # the multiplier value from 0-127 gets scaled to a value from 1/4 to 16/4
         idx = find_nearest_idx(multiplier_mid, multiplier)
         multiplier = multiplier_val[idx]

--- a/module/synthesizer/synthesizer.ini
+++ b/module/synthesizer/synthesizer.ini
@@ -10,20 +10,24 @@ port=6379
 [pyaudio]
 output_device_index=1
 
-[synthesizer]
+[control]
 vco_sin=launchcontrol.control077
 vco_tri=launchcontrol.control078
 vco_saw=launchcontrol.control079
 vco_sqr=launchcontrol.control080
-vco_pitch=launchcontrol.control081
+
+; vco_pitch=launchcontrol.note
 ; vco_pitch=keyboard.note
-; vco_pitch=sequencer.note
+vco_pitch=sequencer.note
+
 lfo_frequency=launchcontrol.control082
 lfo_depth=launchcontrol.control083
 vca_envelope=launchcontrol.control084
-adsr_gate=launchcontrol.note
+
+; adsr_gate=launchcontrol.note
 ; adsr_gate=keyboard.note
-; adsr_gate=sequencer.note
+adsr_gate=sequencer.note
+
 adsr_attack=launchcontrol.control049
 adsr_decay=launchcontrol.control050
 adsr_sustain=launchcontrol.control051

--- a/module/synthesizer/synthesizer.ini
+++ b/module/synthesizer/synthesizer.ini
@@ -10,35 +10,21 @@ port=6379
 [pyaudio]
 output_device_index=1
 
-[default]
-vco_sin=0.75
-vco_tri=0.00
-vco_saw=0.25
-vco_sqr=0.00
-vco_pitch=64
-lfo_frequency=64
-lfo_depth=64
-adsr_attack=16
-adsr_decay=16
-adsr_sustain=64
-adsr_release=32
-vca_envelope=64
-
-[input]
+[synthesizer]
 vco_sin=launchcontrol.control077
 vco_tri=launchcontrol.control078
 vco_saw=launchcontrol.control079
 vco_sqr=launchcontrol.control080
-; vco_pitch=launchcontrol.control081
+vco_pitch=launchcontrol.control081
 ; vco_pitch=keyboard.note
-vco_pitch=sequencer.note
+; vco_pitch=sequencer.note
 lfo_frequency=launchcontrol.control082
 lfo_depth=launchcontrol.control083
-; adsr_gate=launchcontrol.note
+vca_envelope=launchcontrol.control084
+adsr_gate=launchcontrol.note
 ; adsr_gate=keyboard.note
-adsr_gate=sequencer.note
+; adsr_gate=sequencer.note
 adsr_attack=launchcontrol.control049
 adsr_decay=launchcontrol.control050
 adsr_sustain=launchcontrol.control051
 adsr_release=launchcontrol.control052
-vca_envelope=launchcontrol.control084

--- a/module/synthesizer/synthesizer.py
+++ b/module/synthesizer/synthesizer.py
@@ -48,7 +48,7 @@ config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
 try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'),port=config.getint('redis','port'),db=0)
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
@@ -59,7 +59,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 def default(x, y):
     if x is None:
@@ -77,9 +77,9 @@ for i, dev in enumerate(devices):
     print "%d - %s" % (i, dev['name'])
 print('-------------------------')
 
-BLOCKSIZE = int(config.get('general','blocksize'))
+BLOCKSIZE = int(patch.getstring('general','blocksize'))
 CHANNELS  = 1
-BITRATE   = int(config.get('general','bitrate'))
+BITRATE   = int(patch.getstring('general','bitrate'))
 BITS      = p.get_format_from_width(1)
 
 lock = threading.Lock()
@@ -88,7 +88,7 @@ stream = p.open(format = BITS,
 		channels = CHANNELS,
 		rate = BITRATE,
 		output = True,
-		output_device_index = config.getint('pyaudio','output_device_index'))
+		output_device_index = patch.getint('pyaudio','output_device_index'))
 
 class TriggerThread(threading.Thread):
     def __init__(self, r, config):
@@ -104,7 +104,7 @@ class TriggerThread(threading.Thread):
         self.running = False
     def run(self):
         pubsub = self.r.pubsub()
-        channel = self.config.get('input','adsr_gate')
+        channel = self.patch.getstring('input','adsr_gate')
         pubsub.subscribe(channel)
         while self.running:
            for item in pubsub.listen():
@@ -143,35 +143,35 @@ class ControlThread(threading.Thread):
           ################################################################################
           # VCO
           ################################################################################
-          vco_pitch = self.r.get(config.get('input','vco_pitch'))
+          vco_pitch = self.r.get(patch.getstring('input','vco_pitch'))
           if vco_pitch:
               vco_pitch = float(vco_pitch)
           else:
-              vco_pitch = self.config.getfloat('default','vco_pitch')
+              vco_pitch = self.patch.getfloat('default','vco_pitch')
 
-          vco_sin = self.r.get(self.config.get('input','vco_sin'))
+          vco_sin = self.r.get(self.patch.getstring('input','vco_sin'))
           if vco_sin:
               vco_sin = float(vco_sin)
           else:
-              vco_sin = self.config.getfloat('default','vco_sin')
+              vco_sin = self.patch.getfloat('default','vco_sin')
 
-          vco_tri = self.r.get(self.config.get('input','vco_tri'))
+          vco_tri = self.r.get(self.patch.getstring('input','vco_tri'))
           if vco_tri:
               vco_tri = float(vco_tri)
           else:
-              vco_tri = self.config.getfloat('default','vco_tri')
+              vco_tri = self.patch.getfloat('default','vco_tri')
 
-          vco_saw = self.r.get(self.config.get('input','vco_saw'))
+          vco_saw = self.r.get(self.patch.getstring('input','vco_saw'))
           if vco_saw:
               vco_saw = float(vco_saw)
           else:
-              vco_saw = self.config.getfloat('default','vco_saw')
+              vco_saw = self.patch.getfloat('default','vco_saw')
 
-          vco_sqr = self.r.get(self.config.get('input','vco_sqr'))
+          vco_sqr = self.r.get(self.patch.getstring('input','vco_sqr'))
           if vco_sqr:
               vco_sqr = float(vco_sqr)
           else:
-            vco_sqr = self.config.getfloat('default','vco_sqr')
+            vco_sqr = self.patch.getfloat('default','vco_sqr')
 
           vco_total = vco_sin + vco_tri + vco_saw + vco_sqr
           if vco_total>0:
@@ -184,48 +184,48 @@ class ControlThread(threading.Thread):
           ################################################################################
           # LFO
           ################################################################################
-          lfo_frequency = self.r.get(self.config.get('input','lfo_frequency'))
+          lfo_frequency = self.r.get(self.patch.getstring('input','lfo_frequency'))
           if lfo_frequency:
               lfo_frequency = float(lfo_frequency)
           else:
-              lfo_frequency = self.config.getfloat('default','lfo_frequency')
+              lfo_frequency = self.patch.getfloat('default','lfo_frequency')
           # assume that this value is between 0 and 127
           lfo_frequency = lfo_frequency/3
 
-          lfo_depth = self.r.get(self.config.get('input','lfo_depth'))
+          lfo_depth = self.r.get(self.patch.getstring('input','lfo_depth'))
           if lfo_depth:
               lfo_depth = float(lfo_depth)
           else:
-              lfo_depth = self.config.getfloat('default','lfo_depth')
+              lfo_depth = self.patch.getfloat('default','lfo_depth')
           # assume that this value is between 0 and 127
           lfo_depth = lfo_depth/127
 
           ################################################################################
           # ADSR
           ################################################################################
-          adsr_attack = self.r.get(self.config.get('input','adsr_attack'))
+          adsr_attack = self.r.get(self.patch.getstring('input','adsr_attack'))
           if adsr_attack:
               adsr_attack = float(adsr_attack)
           else:
-              adsr_attack = self.config.getfloat('default','adsr_attack')
+              adsr_attack = self.patch.getfloat('default','adsr_attack')
 
-          adsr_decay = self.r.get(self.config.get('input','adsr_decay'))
+          adsr_decay = self.r.get(self.patch.getstring('input','adsr_decay'))
           if adsr_decay:
               adsr_decay = float(adsr_decay)
           else:
-              adsr_decay = self.config.getfloat('default','adsr_decay')
+              adsr_decay = self.patch.getfloat('default','adsr_decay')
 
-          adsr_sustain = self.r.get(self.config.get('input','adsr_sustain'))
+          adsr_sustain = self.r.get(self.patch.getstring('input','adsr_sustain'))
           if adsr_sustain:
               adsr_sustain = float(adsr_sustain)
           else:
-              adsr_sustain = self.config.getfloat('default','adsr_sustain')
+              adsr_sustain = self.patch.getfloat('default','adsr_sustain')
 
-          adsr_release = self.r.get(self.config.get('input','adsr_release'))
+          adsr_release = self.r.get(self.patch.getstring('input','adsr_release'))
           if adsr_release:
               adsr_release = float(adsr_release)
           else:
-              adsr_release = self.config.getfloat('default','adsr_release')
+              adsr_release = self.patch.getfloat('default','adsr_release')
 
           # convert from value between 0 and 127 into time in samples
           adsr_attack   *= float(BITRATE)/127
@@ -236,11 +236,11 @@ class ControlThread(threading.Thread):
           ################################################################################
           # VCA
           ################################################################################
-          vca_envelope = self.r.get(self.config.get('input','vca_envelope'))
+          vca_envelope = self.r.get(self.patch.getstring('input','vca_envelope'))
           if vca_envelope:
               vca_envelope = float(vca_envelope)
           else:
-              vca_envelope = self.config.getfloat('default','vca_envelope')
+              vca_envelope = self.patch.getfloat('default','vca_envelope')
           # assume that this value is between 0 and 127
           vca_envelope = vca_envelope/127.0
 

--- a/module/synthesizer/synthesizer.py
+++ b/module/synthesizer/synthesizer.py
@@ -47,15 +47,15 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
-# this determines how much debugging information gets printed
-debug = config.getint('general','debug')
-
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'),port=config.getint('redis','port'),db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
+
+# this determines how much debugging information gets printed
+debug = config.getint('general','debug')
 
 def default(x, y):
     if x is None:

--- a/module/synthesizer/synthesizer.py
+++ b/module/synthesizer/synthesizer.py
@@ -48,7 +48,7 @@ config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
 try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
     print "Error: cannot connect to redis server"
@@ -59,7 +59,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = patch.getint('general','debug')
+debug = patch.getint('general', 'debug')
 
 def default(x, y):
     if x is None:
@@ -77,9 +77,9 @@ for i, dev in enumerate(devices):
     print "%d - %s" % (i, dev['name'])
 print('-------------------------')
 
-BLOCKSIZE = int(patch.getstring('general','blocksize'))
+BLOCKSIZE = int(patch.getstring('general', 'blocksize'))
 CHANNELS  = 1
-BITRATE   = int(patch.getstring('general','bitrate'))
+BITRATE   = int(patch.getstring('general', 'bitrate'))
 BITS      = p.get_format_from_width(1)
 
 lock = threading.Lock()
@@ -88,13 +88,12 @@ stream = p.open(format = BITS,
 		channels = CHANNELS,
 		rate = BITRATE,
 		output = True,
-		output_device_index = patch.getint('pyaudio','output_device_index'))
+		output_device_index = patch.getint('pyaudio', 'output_device_index'))
 
 class TriggerThread(threading.Thread):
-    def __init__(self, r, config):
+    def __init__(self, r):
         threading.Thread.__init__(self)
         self.r = r
-        self.config = config
         self.running = True
         lock.acquire()
         self.time = 0
@@ -104,8 +103,8 @@ class TriggerThread(threading.Thread):
         self.running = False
     def run(self):
         pubsub = self.r.pubsub()
-        channel = self.patch.getstring('input','adsr_gate')
-        pubsub.subscribe(channel)
+        pubsub.subscribe('SYNTHESIZER_UNBLOCK')  # this message unblocks the redis listen command
+        pubsub.subscribe(patch.getstring('synthesizer', 'adsr_gate'))
         while self.running:
            for item in pubsub.listen():
                if not self.running or not item['type'] == 'message':
@@ -116,10 +115,9 @@ class TriggerThread(threading.Thread):
                lock.release()
 
 class ControlThread(threading.Thread):
-    def __init__(self, r, config):
+    def __init__(self, r):
         threading.Thread.__init__(self)
         self.r = r
-        self.config = config
         self.running = True
         lock.acquire()
         self.vco_pitch      = 0
@@ -139,39 +137,14 @@ class ControlThread(threading.Thread):
         self.running = False
     def run(self):
       while self.running:
-
           ################################################################################
           # VCO
           ################################################################################
-          vco_pitch = self.r.get(patch.getstring('input','vco_pitch'))
-          if vco_pitch:
-              vco_pitch = float(vco_pitch)
-          else:
-              vco_pitch = self.patch.getfloat('default','vco_pitch')
-
-          vco_sin = self.r.get(self.patch.getstring('input','vco_sin'))
-          if vco_sin:
-              vco_sin = float(vco_sin)
-          else:
-              vco_sin = self.patch.getfloat('default','vco_sin')
-
-          vco_tri = self.r.get(self.patch.getstring('input','vco_tri'))
-          if vco_tri:
-              vco_tri = float(vco_tri)
-          else:
-              vco_tri = self.patch.getfloat('default','vco_tri')
-
-          vco_saw = self.r.get(self.patch.getstring('input','vco_saw'))
-          if vco_saw:
-              vco_saw = float(vco_saw)
-          else:
-              vco_saw = self.patch.getfloat('default','vco_saw')
-
-          vco_sqr = self.r.get(self.patch.getstring('input','vco_sqr'))
-          if vco_sqr:
-              vco_sqr = float(vco_sqr)
-          else:
-            vco_sqr = self.patch.getfloat('default','vco_sqr')
+          vco_pitch = patch.getfloat('synthesizer', 'vco_pitch', default=60)
+          vco_sin   = patch.getfloat('synthesizer', 'vco_sin', default=0.75)
+          vco_tri   = patch.getfloat('synthesizer', 'vco_tri', default=0.00)
+          vco_saw   = patch.getfloat('synthesizer', 'vco_saw', default=0.25)
+          vco_sqr   = patch.getfloat('synthesizer', 'vco_sqr', default=0.00)
 
           vco_total = vco_sin + vco_tri + vco_saw + vco_sqr
           if vco_total>0:
@@ -184,65 +157,27 @@ class ControlThread(threading.Thread):
           ################################################################################
           # LFO
           ################################################################################
-          lfo_frequency = self.r.get(self.patch.getstring('input','lfo_frequency'))
-          if lfo_frequency:
-              lfo_frequency = float(lfo_frequency)
-          else:
-              lfo_frequency = self.patch.getfloat('default','lfo_frequency')
-          # assume that this value is between 0 and 127
-          lfo_frequency = lfo_frequency/3
-
-          lfo_depth = self.r.get(self.patch.getstring('input','lfo_depth'))
-          if lfo_depth:
-              lfo_depth = float(lfo_depth)
-          else:
-              lfo_depth = self.patch.getfloat('default','lfo_depth')
-          # assume that this value is between 0 and 127
-          lfo_depth = lfo_depth/127
+          lfo_frequency = patch.getfloat('synthesizer', 'lfo_frequency', default=2)
+          lfo_depth     = patch.getfloat('synthesizer', 'lfo_depth', default=0.5)
 
           ################################################################################
           # ADSR
           ################################################################################
-          adsr_attack = self.r.get(self.patch.getstring('input','adsr_attack'))
-          if adsr_attack:
-              adsr_attack = float(adsr_attack)
-          else:
-              adsr_attack = self.patch.getfloat('default','adsr_attack')
+          adsr_attack   = patch.getfloat('synthesizer', 'adsr_attack', default=0.25)
+          adsr_decay    = patch.getfloat('synthesizer', 'adsr_decay', default=0.25)
+          adsr_sustain  = patch.getfloat('synthesizer', 'adsr_sustain', default=0.5)
+          adsr_release  = patch.getfloat('synthesizer', 'adsr_release', default=0.25)
 
-          adsr_decay = self.r.get(self.patch.getstring('input','adsr_decay'))
-          if adsr_decay:
-              adsr_decay = float(adsr_decay)
-          else:
-              adsr_decay = self.patch.getfloat('default','adsr_decay')
-
-          adsr_sustain = self.r.get(self.patch.getstring('input','adsr_sustain'))
-          if adsr_sustain:
-              adsr_sustain = float(adsr_sustain)
-          else:
-              adsr_sustain = self.patch.getfloat('default','adsr_sustain')
-
-          adsr_release = self.r.get(self.patch.getstring('input','adsr_release'))
-          if adsr_release:
-              adsr_release = float(adsr_release)
-          else:
-              adsr_release = self.patch.getfloat('default','adsr_release')
-
-          # convert from value between 0 and 127 into time in samples
-          adsr_attack   *= float(BITRATE)/127
-          adsr_decay    *= float(BITRATE)/127
-          adsr_sustain  *= float(BITRATE)/127
-          adsr_release  *= float(BITRATE)/127
+          # convert from value between 0 and 1 into time in samples
+          adsr_attack   *= float(BITRATE)
+          adsr_decay    *= float(BITRATE)
+          adsr_sustain  *= float(BITRATE)
+          adsr_release  *= float(BITRATE)
 
           ################################################################################
           # VCA
           ################################################################################
-          vca_envelope = self.r.get(self.patch.getstring('input','vca_envelope'))
-          if vca_envelope:
-              vca_envelope = float(vca_envelope)
-          else:
-              vca_envelope = self.patch.getfloat('default','vca_envelope')
-          # assume that this value is between 0 and 127
-          vca_envelope = vca_envelope/127.0
+          vca_envelope = patch.getfloat('synthesizer', 'vca_envelope', default=0.5)
 
           ################################################################################
           # store the control values in the local object
@@ -261,13 +196,27 @@ class ControlThread(threading.Thread):
           self.adsr_release     = adsr_release
           self.vca_envelope     = vca_envelope
           lock.release()
+          if debug>2:
+              print '----------------------------------'
+              print 'vco_pitch      =', vco_pitch
+              print 'vco_sin        =', vco_sin
+              print 'vco_tri        =', vco_tri
+              print 'vco_saw        =', vco_saw
+              print 'vco_sqr        =', vco_sqr
+              print 'lfo_depth      =', lfo_depth
+              print 'lfo_frequency  =', lfo_frequency
+              print 'adsr_attack    =', adsr_attack
+              print 'adsr_decay     =', adsr_decay
+              print 'adsr_sustain   =', adsr_sustain
+              print 'adsr_release   =', adsr_release
+              print 'vca_envelope   =', vca_envelope
 
 # start the background thread that deals with control value changes
-control = ControlThread(r, config)
+control = ControlThread(r)
 control.start()
 
 # start the background thread that deals with triggers
-trigger = TriggerThread(r, config)
+trigger = TriggerThread(r)
 trigger.start()
 
 offset = 0
@@ -341,10 +290,12 @@ try:
     offset = offset+BLOCKSIZE
 
 except KeyboardInterrupt:
-    trigger.stop()
+    print "Closing threads"
     control.stop()
-    trigger.join()
     control.join()
+    trigger.stop()
+    r.publish('SYNTHESIZER_UNBLOCK', 1)
+    trigger.join()
     stream.stop_stream()
     stream.close()
     p.terminate()

--- a/module/synthesizer/synthesizer.py
+++ b/module/synthesizer/synthesizer.py
@@ -54,6 +54,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 

--- a/module/synthesizer/synthesizer.py
+++ b/module/synthesizer/synthesizer.py
@@ -104,7 +104,7 @@ class TriggerThread(threading.Thread):
     def run(self):
         pubsub = self.r.pubsub()
         pubsub.subscribe('SYNTHESIZER_UNBLOCK')  # this message unblocks the redis listen command
-        pubsub.subscribe(patch.getstring('synthesizer', 'adsr_gate'))
+        pubsub.subscribe(patch.getstring('control', 'adsr_gate'))
         while self.running:
            for item in pubsub.listen():
                if not self.running or not item['type'] == 'message':
@@ -140,11 +140,11 @@ class ControlThread(threading.Thread):
           ################################################################################
           # VCO
           ################################################################################
-          vco_pitch = patch.getfloat('synthesizer', 'vco_pitch', default=60)
-          vco_sin   = patch.getfloat('synthesizer', 'vco_sin', default=0.75)
-          vco_tri   = patch.getfloat('synthesizer', 'vco_tri', default=0.00)
-          vco_saw   = patch.getfloat('synthesizer', 'vco_saw', default=0.25)
-          vco_sqr   = patch.getfloat('synthesizer', 'vco_sqr', default=0.00)
+          vco_pitch = patch.getfloat('control', 'vco_pitch', default=60)
+          vco_sin   = patch.getfloat('control', 'vco_sin', default=0.75)
+          vco_tri   = patch.getfloat('control', 'vco_tri', default=0.00)
+          vco_saw   = patch.getfloat('control', 'vco_saw', default=0.25)
+          vco_sqr   = patch.getfloat('control', 'vco_sqr', default=0.00)
 
           vco_total = vco_sin + vco_tri + vco_saw + vco_sqr
           if vco_total>0:
@@ -157,16 +157,16 @@ class ControlThread(threading.Thread):
           ################################################################################
           # LFO
           ################################################################################
-          lfo_frequency = patch.getfloat('synthesizer', 'lfo_frequency', default=2)
-          lfo_depth     = patch.getfloat('synthesizer', 'lfo_depth', default=0.5)
+          lfo_frequency = patch.getfloat('control', 'lfo_frequency', default=2)
+          lfo_depth     = patch.getfloat('control', 'lfo_depth', default=0.5)
 
           ################################################################################
           # ADSR
           ################################################################################
-          adsr_attack   = patch.getfloat('synthesizer', 'adsr_attack', default=0.25)
-          adsr_decay    = patch.getfloat('synthesizer', 'adsr_decay', default=0.25)
-          adsr_sustain  = patch.getfloat('synthesizer', 'adsr_sustain', default=0.5)
-          adsr_release  = patch.getfloat('synthesizer', 'adsr_release', default=0.25)
+          adsr_attack   = patch.getfloat('control', 'adsr_attack', default=0.25)
+          adsr_decay    = patch.getfloat('control', 'adsr_decay', default=0.25)
+          adsr_sustain  = patch.getfloat('control', 'adsr_sustain', default=0.5)
+          adsr_release  = patch.getfloat('control', 'adsr_release', default=0.25)
 
           # convert from value between 0 and 1 into time in samples
           adsr_attack   *= float(BITRATE)
@@ -177,7 +177,7 @@ class ControlThread(threading.Thread):
           ################################################################################
           # VCA
           ################################################################################
-          vca_envelope = patch.getfloat('synthesizer', 'vca_envelope', default=0.5)
+          vca_envelope = patch.getfloat('control', 'vca_envelope', default=0.5)
 
           ################################################################################
           # store the control values in the local object
@@ -219,11 +219,13 @@ control.start()
 trigger = TriggerThread(r)
 trigger.start()
 
+block = 0
 offset = 0
+
 try:
   while True:
     ################################################################################
-    # generate the signal
+    # this is constantly generating the output signal
     ################################################################################
     BUFFER = ''
 

--- a/module/volcabass/volcabass.py
+++ b/module/volcabass/volcabass.py
@@ -47,6 +47,13 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+try:
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print "Error: cannot connect to redis server"
+    exit()
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -56,15 +63,6 @@ control_name = ['slide_time', 'expression', 'octave', 'lfo_rate', 'lfo_int', 'vc
 control_code = [5, 11, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
 note_name = ['C0', 'Db0', 'D0', 'Eb0', 'E0', 'F0', 'Gb0', 'G0', 'Ab0', 'A0', 'Bb0', 'B0', 'C1', 'Db1', 'D1', 'Eb1', 'E1', 'F1', 'Gb1', 'G1', 'Ab1', 'A1', 'Bb1', 'B1', 'C2', 'Db2', 'D2', 'Eb2', 'E2', 'F2', 'Gb2', 'G2', 'Ab2', 'A2', 'Bb2', 'B2', 'C3', 'Db3', 'D3', 'Eb3', 'E3', 'F3', 'Gb3', 'G3', 'Ab3', 'A3', 'Bb3', 'B3', 'C4', 'Db4', 'D4', 'Eb4', 'E4', 'F4', 'Gb4', 'G4', 'Ab4', 'A4', 'Bb4', 'B4', 'C5', 'Db5', 'D5', 'Eb5', 'E5', 'F5', 'Gb5', 'G5', 'Ab5', 'A5', 'Bb5', 'B5', 'C6', 'Db6', 'D6', 'Eb6', 'E6', 'F6', 'Gb6', 'G6', 'Ab6', 'A6', 'Bb6', 'B6', 'C7', 'Db7', 'D7', 'Eb7', 'E7', 'F7', 'Gb7', 'G7', 'Ab7', 'A7', 'Bb7', 'B7', 'C8', 'Db8', 'D8', 'Eb8', 'E8', 'F8', 'Gb8', 'G8', 'Ab8', 'A8', 'Bb8', 'B8', 'C9', 'Db9', 'D9', 'Eb9', 'E9', 'F9', 'Gb9', 'G9', 'Ab9', 'A9', 'Bb9', 'B9', 'C10', 'Db10', 'D10', 'Eb10', 'E10', 'F10', 'Gb10', 'G10', 'Ab10', 'A10', 'Bb10', 'B10']
 note_code = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
-
-try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
-    response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
-except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
-    exit()
 
 midichannel = config.getint('midi', 'channel')-1  # channel 1-16 get mapped to 0-15
 outputport = EEGsynth.midiwrapper(config)

--- a/module/volcabass/volcabass.py
+++ b/module/volcabass/volcabass.py
@@ -59,7 +59,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # the list of MIDI commands is the only aspect that is specific to the Volca Bass
 # see http://media.aadl.org/files/catalog_guides/1444141_chart.pdf
@@ -68,7 +68,7 @@ control_code = [5, 11, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]
 note_name = ['C0', 'Db0', 'D0', 'Eb0', 'E0', 'F0', 'Gb0', 'G0', 'Ab0', 'A0', 'Bb0', 'B0', 'C1', 'Db1', 'D1', 'Eb1', 'E1', 'F1', 'Gb1', 'G1', 'Ab1', 'A1', 'Bb1', 'B1', 'C2', 'Db2', 'D2', 'Eb2', 'E2', 'F2', 'Gb2', 'G2', 'Ab2', 'A2', 'Bb2', 'B2', 'C3', 'Db3', 'D3', 'Eb3', 'E3', 'F3', 'Gb3', 'G3', 'Ab3', 'A3', 'Bb3', 'B3', 'C4', 'Db4', 'D4', 'Eb4', 'E4', 'F4', 'Gb4', 'G4', 'Ab4', 'A4', 'Bb4', 'B4', 'C5', 'Db5', 'D5', 'Eb5', 'E5', 'F5', 'Gb5', 'G5', 'Ab5', 'A5', 'Bb5', 'B5', 'C6', 'Db6', 'D6', 'Eb6', 'E6', 'F6', 'Gb6', 'G6', 'Ab6', 'A6', 'Bb6', 'B6', 'C7', 'Db7', 'D7', 'Eb7', 'E7', 'F7', 'Gb7', 'G7', 'Ab7', 'A7', 'Bb7', 'B7', 'C8', 'Db8', 'D8', 'Eb8', 'E8', 'F8', 'Gb8', 'G8', 'Ab8', 'A8', 'Bb8', 'B8', 'C9', 'Db9', 'D9', 'Eb9', 'E9', 'F9', 'Gb9', 'G9', 'Ab9', 'A9', 'Bb9', 'B9', 'C10', 'Db10', 'D10', 'Eb10', 'E10', 'F10', 'Gb10', 'G10', 'Ab10', 'A10', 'Bb10', 'B10']
 note_code = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
 
-midichannel = config.getint('midi', 'channel')-1  # channel 1-16 get mapped to 0-15
+midichannel = patch.getint('midi', 'channel')-1  # channel 1-16 get mapped to 0-15
 outputport = EEGsynth.midiwrapper(config)
 outputport.open_output()
 
@@ -104,7 +104,7 @@ trigger = []
 for name, code in zip(note_name, note_code):
     try:
         # start the background thread that deals with the trigger
-        this = TriggerThread(config.get('note', name), code)
+        this = TriggerThread(patch.getstring('note', name), code)
         trigger.append(this)
         print name+' OK'
     except:
@@ -122,13 +122,13 @@ for name in control_name:
 
 try:
     while True:
-        time.sleep(config.getfloat('general', 'delay'))
+        time.sleep(patch.getfloat('general', 'delay'))
 
         for name, cmd in zip(control_name, control_code):
             # loop over the control values
             if not config.has_option('control', name):
                 continue # it should be skipped when commented out in the ini file
-            val = r.get(config.get('control', name))
+            val = r.get(patch.getstring('control', name))
             if val:
                 val = float(val)
             else:

--- a/module/volcabass/volcabass.py
+++ b/module/volcabass/volcabass.py
@@ -54,6 +54,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 

--- a/module/volcabass/volcabass.py
+++ b/module/volcabass/volcabass.py
@@ -126,14 +126,9 @@ try:
 
         for name, cmd in zip(control_name, control_code):
             # loop over the control values
-            if not config.has_option('control', name):
-                continue # it should be skipped when commented out in the ini file
-            val = r.get(patch.getstring('control', name))
-            if val:
-                val = float(val)
-            else:
+            val = patch.getint('control', name)
+            if val==None:
                 continue # it should be skipped when not present
-            val = int(val)
             if val==previous_val[name]:
                 continue # it should be skipped when identical to the previous value
             previous_val[name] = val

--- a/module/volcabeats/volcabeats.py
+++ b/module/volcabeats/volcabeats.py
@@ -47,6 +47,13 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+try:
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print "Error: cannot connect to redis server"
+    exit()
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -56,15 +63,6 @@ control_name = ['kick_level', 'snare_level', 'lo_tom_level', 'hi_tom_level', 'cl
 control_code = [40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59]
 note_name = ['kick', 'snare', 'lo_tom', 'hi_tom', 'closed_hat', 'open_hat', 'clap']
 note_code = [36, 38, 43, 50, 42, 46, 39]
-
-try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
-    response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
-except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
-    exit()
 
 # this is only for debugging
 print('------ OUTPUT ------')

--- a/module/volcabeats/volcabeats.py
+++ b/module/volcabeats/volcabeats.py
@@ -54,6 +54,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 

--- a/module/volcabeats/volcabeats.py
+++ b/module/volcabeats/volcabeats.py
@@ -59,7 +59,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # the list of MIDI commands is the only aspect that is specific to the Volca Beats
 # see http://media.aadl.org/files/catalog_guides/1445131_chart.pdf
@@ -74,7 +74,7 @@ for port in mido.get_output_names():
   print(port)
 print('-------------------------')
 
-midichannel = config.getint('midi', 'channel')-1  # channel 1-16 get mapped to 0-15
+midichannel = patch.getint('midi', 'channel')-1  # channel 1-16 get mapped to 0-15
 outputport = EEGsynth.midiwrapper(config)
 outputport.open_output()
 
@@ -110,7 +110,7 @@ trigger = []
 for name, code in zip(note_name, note_code):
     try:
         # start the background thread that deals with the trigger
-        this = TriggerThread(config.get('note', name), code)
+        this = TriggerThread(patch.getstring('note', name), code)
         trigger.append(this)
         print name+' OK'
     except:
@@ -128,13 +128,13 @@ for name in control_name:
 
 try:
     while True:
-        time.sleep(config.getfloat('general', 'delay'))
+        time.sleep(patch.getfloat('general', 'delay'))
 
         for name, cmd in zip(control_name, control_code):
             # loop over the control values
             if not config.has_option('control', name):
                 continue # it should be skipped when commented out in the ini file
-            val = r.get(config.get('control', name))
+            val = r.get(patch.getstring('control', name))
             if val:
                 val = float(val)
             else:

--- a/module/volcabeats/volcabeats.py
+++ b/module/volcabeats/volcabeats.py
@@ -132,14 +132,9 @@ try:
 
         for name, cmd in zip(control_name, control_code):
             # loop over the control values
-            if not config.has_option('control', name):
-                continue # it should be skipped when commented out in the ini file
-            val = r.get(patch.getstring('control', name))
-            if val:
-                val = float(val)
-            else:
+            val = patch.getint('control', name)
+            if val==None:
                 continue # it should be skipped when not present
-            val = int(val)
             if val==previous_val[name]:
                 continue # it should be skipped when identical to the previous value
             previous_val[name] = val

--- a/module/volcakeys/volcakeys.py
+++ b/module/volcakeys/volcakeys.py
@@ -47,6 +47,13 @@ args = parser.parse_args()
 config = ConfigParser.ConfigParser()
 config.read(args.inifile)
 
+try:
+    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print "Error: cannot connect to redis server"
+    exit()
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 
@@ -56,15 +63,6 @@ control_name = ['portamento', 'expression', 'voice', 'octave', 'detune', 'vco_eg
 control_code = [5, 11, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53]
 note_name = ['C0', 'Db0', 'D0', 'Eb0', 'E0', 'F0', 'Gb0', 'G0', 'Ab0', 'A0', 'Bb0', 'B0', 'C1', 'Db1', 'D1', 'Eb1', 'E1', 'F1', 'Gb1', 'G1', 'Ab1', 'A1', 'Bb1', 'B1', 'C2', 'Db2', 'D2', 'Eb2', 'E2', 'F2', 'Gb2', 'G2', 'Ab2', 'A2', 'Bb2', 'B2', 'C3', 'Db3', 'D3', 'Eb3', 'E3', 'F3', 'Gb3', 'G3', 'Ab3', 'A3', 'Bb3', 'B3', 'C4', 'Db4', 'D4', 'Eb4', 'E4', 'F4', 'Gb4', 'G4', 'Ab4', 'A4', 'Bb4', 'B4', 'C5', 'Db5', 'D5', 'Eb5', 'E5', 'F5', 'Gb5', 'G5', 'Ab5', 'A5', 'Bb5', 'B5', 'C6', 'Db6', 'D6', 'Eb6', 'E6', 'F6', 'Gb6', 'G6', 'Ab6', 'A6', 'Bb6', 'B6', 'C7', 'Db7', 'D7', 'Eb7', 'E7', 'F7', 'Gb7', 'G7', 'Ab7', 'A7', 'Bb7', 'B7', 'C8', 'Db8', 'D8', 'Eb8', 'E8', 'F8', 'Gb8', 'G8', 'Ab8', 'A8', 'Bb8', 'B8', 'C9', 'Db9', 'D9', 'Eb9', 'E9', 'F9', 'Gb9', 'G9', 'Ab9', 'A9', 'Bb9', 'B9', 'C10', 'Db10', 'D10', 'Eb10', 'E10', 'F10', 'Gb10', 'G10', 'Ab10', 'A10', 'Bb10', 'B10']
 note_code = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
-
-try:
-    r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
-    response = r.client_list()
-    if debug>0:
-        print "Connected to redis server"
-except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
-    exit()
 
 midichannel = config.getint('midi', 'channel')-1  # channel 1-16 get mapped to 0-15
 outputport = EEGsynth.midiwrapper(config)

--- a/module/volcakeys/volcakeys.py
+++ b/module/volcakeys/volcakeys.py
@@ -59,7 +59,7 @@ patch = EEGsynth.patch(config, r)
 del config
 
 # this determines how much debugging information gets printed
-debug = config.getint('general','debug')
+debug = patch.getint('general','debug')
 
 # the list of MIDI commands is the only aspect that is specific to the Volca Keys
 # see http://media.aadl.org/files/catalog_guides/1444140_chart.pdf
@@ -68,7 +68,7 @@ control_code = [5, 11, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53]
 note_name = ['C0', 'Db0', 'D0', 'Eb0', 'E0', 'F0', 'Gb0', 'G0', 'Ab0', 'A0', 'Bb0', 'B0', 'C1', 'Db1', 'D1', 'Eb1', 'E1', 'F1', 'Gb1', 'G1', 'Ab1', 'A1', 'Bb1', 'B1', 'C2', 'Db2', 'D2', 'Eb2', 'E2', 'F2', 'Gb2', 'G2', 'Ab2', 'A2', 'Bb2', 'B2', 'C3', 'Db3', 'D3', 'Eb3', 'E3', 'F3', 'Gb3', 'G3', 'Ab3', 'A3', 'Bb3', 'B3', 'C4', 'Db4', 'D4', 'Eb4', 'E4', 'F4', 'Gb4', 'G4', 'Ab4', 'A4', 'Bb4', 'B4', 'C5', 'Db5', 'D5', 'Eb5', 'E5', 'F5', 'Gb5', 'G5', 'Ab5', 'A5', 'Bb5', 'B5', 'C6', 'Db6', 'D6', 'Eb6', 'E6', 'F6', 'Gb6', 'G6', 'Ab6', 'A6', 'Bb6', 'B6', 'C7', 'Db7', 'D7', 'Eb7', 'E7', 'F7', 'Gb7', 'G7', 'Ab7', 'A7', 'Bb7', 'B7', 'C8', 'Db8', 'D8', 'Eb8', 'E8', 'F8', 'Gb8', 'G8', 'Ab8', 'A8', 'Bb8', 'B8', 'C9', 'Db9', 'D9', 'Eb9', 'E9', 'F9', 'Gb9', 'G9', 'Ab9', 'A9', 'Bb9', 'B9', 'C10', 'Db10', 'D10', 'Eb10', 'E10', 'F10', 'Gb10', 'G10', 'Ab10', 'A10', 'Bb10', 'B10']
 note_code = [12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143]
 
-midichannel = config.getint('midi', 'channel')-1  # channel 1-16 get mapped to 0-15
+midichannel = patch.getint('midi', 'channel')-1  # channel 1-16 get mapped to 0-15
 outputport = EEGsynth.midiwrapper(config)
 outputport.open_output()
 
@@ -104,7 +104,7 @@ trigger = []
 for name, code in zip(note_name, note_code):
     if config.has_option('note', name):
         # start the background thread that deals with this note
-        this = TriggerThread(config.get('note', name), code)
+        this = TriggerThread(patch.getstring('note', name), code)
         trigger.append(this)
         if debug>1:
             print name, 'OK'
@@ -120,13 +120,13 @@ for name in control_name:
 
 try:
     while True:
-        time.sleep(config.getfloat('general', 'delay'))
+        time.sleep(patch.getfloat('general', 'delay'))
 
         for name, cmd in zip(control_name, control_code):
             # loop over the control values
             if not config.has_option('control', name):
                 continue # it should be skipped when commented out in the ini file
-            val = r.get(config.get('control', name))
+            val = r.get(patch.getstring('control', name))
             if val:
                 val = float(val)
             else:

--- a/module/volcakeys/volcakeys.py
+++ b/module/volcakeys/volcakeys.py
@@ -54,6 +54,10 @@ except redis.ConnectionError:
     print "Error: cannot connect to redis server"
     exit()
 
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
 # this determines how much debugging information gets printed
 debug = config.getint('general','debug')
 

--- a/module/volcakeys/volcakeys.py
+++ b/module/volcakeys/volcakeys.py
@@ -124,14 +124,9 @@ try:
 
         for name, cmd in zip(control_name, control_code):
             # loop over the control values
-            if not config.has_option('control', name):
-                continue # it should be skipped when commented out in the ini file
-            val = r.get(patch.getstring('control', name))
-            if val:
-                val = float(val)
-            else:
+            val = patch.getint('control', name)
+            if val==None:
                 continue # it should be skipped when not present
-            val = int(val)
             if val==previous_val[name]:
                 continue # it should be skipped when identical to the previous value
             previous_val[name] = val


### PR DESCRIPTION
@stephenwhitmarsh, this addresses #122 

There is now a patch class, which at initialization receives the configuration file object and the redis object. Subsequently, all strings and values should be received from the patch object and not directly from the config file any more.

The current implementation does not include teh indirect patching, i.e. where a redis value would contain a string pointing to another redis key. This is not needed any more now with the improved ini file handling. 