### PR TITLE
removed compressor_expander from regular modules, see #143

### DIFF
--- a/module/calibration/calibration.ini
+++ b/module/calibration/calibration.ini
@@ -2,30 +2,30 @@
 debug=2
 
 [redis]
-hostname=synthpi.local
+hostname=localhost
 port=6379
 
 [calibration]
 stepsize=0.1        ; update time (s)
 
 [input]
-; control values to calibrate, separated by comma
+; one or multiple control values to calibrate, separated by comma
 channels=launchcontrol.control077,launchcontrol.control078
 
 [compressor_expander]
-; the values from redis are compressed/expanded by this, and subsequently scaled and offset
-; these options can be specified as number or as redis channel
+; the values from Redis are compressed/expanded by this, and subsequently scaled and offset
+; these options can be specified as number or as Redis channel
 enable=1                      ; boolean value, can be assigned to a toggle button
 lo=launchcontrol.control049
 hi=launchcontrol.control050
 
 [scale]
-; these options can be specified as number or as redis channel
+; these options can be specified as number or as Redis channel
 launchcontrol.control077=1
 launchcontrol.control078=1
 
 [offset]
-; these options can be specified as number or as redis channel
+; these options can be specified as number or as Redis channel
 launchcontrol.control077=0
 launchcontrol.control078=0
 

--- a/module/endorphines/endorphines.ini
+++ b/module/endorphines/endorphines.ini
@@ -12,13 +12,6 @@ device=Shuttle Control v2
 ;device=Shuttle Control v2 MIDI 1
 ;device=Shuttle Control v2 20:0
 
-[compressor_expander]
-; the values from redis are compressed/expanded by this, and subsequently scaled and offset
-; these options can be specified as number or as redis channel
-enable=1                      ; boolean value, can be assigned to a toggle button
-lo=launchcontrol.control049
-hi=launchcontrol.control050
-
 [control]
 ; this is the top most row of knobs on the LaunchControl XL
 channel1=launchcontrol.control013

--- a/module/endorphines/endorphines.py
+++ b/module/endorphines/endorphines.py
@@ -128,29 +128,18 @@ try:
             # channels are one-offset in the ini file, zero-offset in the code
             name = 'channel{}'.format(channel+1)
             val = patch.getfloat('control', name)
+
             if val is None:
+                # the value is not present in Redis, skip it
                 if debug>2:
                     print name, 'not available'
                 continue
 
-            if patch.getint('compressor_expander', 'enable'):
-                # the compressor applies to all channels and must exist as float or redis key
-                lo = patch.getfloat('compressor_expander', 'lo')
-                hi = patch.getfloat('compressor_expander', 'hi')
-                if lo is None or hi is None:
-                    if debug>1:
-                        print "cannot apply compressor/expander"
-                else:
-                    # apply the compressor/expander
-                    val = EEGsynth.compress(val, lo, hi)
-
             # the scale and offset options are channel specific
             scale  = patch.getfloat('scale', name, default=1)
             offset = patch.getfloat('offset', name, default=0)
-
             # apply the scale and offset
             val = EEGsynth.rescale(val, slope=scale, offset=offset)
-
             # ensure that it is within limits
             val = EEGsynth.limit(val, lo=-8192, hi=8191)
 

--- a/module/outputartnet/outputartnet.ini
+++ b/module/outputartnet/outputartnet.ini
@@ -11,13 +11,6 @@ broadcast=192.168.1.255
 port=6454
 universe=1
 
-[compressor_expander]
-; the values from redis are compressed/expanded by this, and subsequently scaled and offset
-; these options can be specified as number or as redis channel
-enable=0                      ; boolean value, can be assigned to a toggle button
-lo=launchcontrol.control049
-hi=launchcontrol.control050
-
 [input]
 ; from 077 onwards are the sliders on the launchcontrol XL
 channel001=launchcontrol.control077

--- a/module/outputartnet/outputartnet.py
+++ b/module/outputartnet/outputartnet.py
@@ -76,29 +76,17 @@ try:
     while True:
         time.sleep(patch.getfloat('general', 'delay'))
 
+        # loop over the control values
         for chanindx in range(1, 256):
             chanstr = "channel%03d" % chanindx
-
-            try:
-                chanval = patch.getfloat('input', chanstr)
-            except:
-                # the channel is not configured in the ini file, skip it
-                continue
+            # this returns None when the channel is not present
+            chanval = patch.getfloat('input', chanstr)
 
             if chanval==None:
-                # the value is not present in redis, skip it
+                # the value is not present in Redis, skip it
+                if debug>2:
+                    print chanstr, 'not available'
                 continue
-
-            if patch.getint('compressor_expander', 'enable'):
-                # the compressor applies to all channels and must exist as float or redis key
-                lo = patch.getfloat('compressor_expander', 'lo')
-                hi = patch.getfloat('compressor_expander', 'hi')
-                if lo is None or hi is None:
-                    if debug>1:
-                        print "cannot apply compressor/expander"
-                else:
-                    # apply the compressor/expander
-                    chanval = EEGsynth.compress(chanval, lo, hi)
 
             # the scale and offset options are channel specific
             scale  = patch.getfloat('scale', chanstr, default=255)

--- a/module/outputcvgate/outputcvgate.ini
+++ b/module/outputcvgate/outputcvgate.ini
@@ -12,13 +12,6 @@ device=/dev/ttyUSB0
 ;device=/dev/tty.wchusbserial1420
 baudrate=115200
 
-[compressor_expander]
-; the values from redis are compressed/expanded by this, and subsequently scaled and offset
-; these options can be specified as number or as redis channel
-enable=1                      ; boolean value, can be assigned to a toggle button
-lo=launchcontrol.control049
-hi=launchcontrol.control050
-
 [scale]
 ; the values from redis are multiplied by this before being sent as control voltage
 ; the 12-bit DAC in the Arduino based cv/gate output expects values between 0-4095

--- a/module/outputdmx512/outputdmx512.ini
+++ b/module/outputdmx512/outputdmx512.ini
@@ -11,12 +11,6 @@ device=/dev/tty.usbserial-AH01DRO4
 baudrate=57600
 ; baudrate=250000
 
-[compressor_expander]
-; the values from redis are compressed/expanded by this, and subsequently scaled and offset
-; these options can be specified as number or as redis channel
-enable=1                      ; boolean value, can be assigned to a toggle button
-lo=launchcontrol.control049
-hi=launchcontrol.control050
 
 [input]
 ; from 077 onwards are the sliders on the launchcontrol XL

--- a/module/outputdmx512/outputdmx512.py
+++ b/module/outputdmx512/outputdmx512.py
@@ -145,27 +145,14 @@ try:
 
         for chanindx in range(1, 512):
             chanstr = "channel%03d" % chanindx
-
-            try:
-                chanval = patch.getfloat('input', chanstr)
-            except:
-                # the channel is not configured in the ini file, skip it
-                continue
+            # this returns None when the channel is not present
+            chanval = patch.getfloat('input', chanstr)
 
             if chanval==None:
-                # the value is not present in redis, skip it
+                # the value is not present in Redis, skip it
+                if debug>2:
+                    print chanstr, 'not available'
                 continue
-
-            if patch.getint('compressor_expander', 'enable'):
-                # the compressor applies to all channels and must exist as float or redis key
-                lo = patch.getfloat('compressor_expander', 'lo')
-                hi = patch.getfloat('compressor_expander', 'hi')
-                if lo is None or hi is None:
-                    if debug>1:
-                        print "cannot apply compressor/expander"
-                else:
-                    # apply the compressor/expander
-                    chanval = EEGsynth.compress(chanval, lo, hi)
 
             # the scale and offset options are channel specific
             scale  = patch.getfloat('scale', chanstr, default=255)

--- a/module/outputosc/outputosc.ini
+++ b/module/outputosc/outputosc.ini
@@ -11,16 +11,8 @@ port=6379
 hostname=localhost
 port=9000
 
-[compressor_expander]
-; the values from redis are compressed/expanded by this, and subsequently scaled and offset
-; these options can be specified as number or as redis channel
-enable=1                      ; boolean value, can be assigned to a toggle button
-lo=launchcontrol.control049
-hi=launchcontrol.control050
-
 [input]
-; the keys here can have an arbitrary name, but should map those in the other sections
-; the keys must be lower-case
+; the keys here can have an arbitrary lower-case name, but should map those in the other sections
 key01=launchcontrol.control077
 key02=launchcontrol.control078
 key03=launchcontrol.control079
@@ -43,8 +35,7 @@ key03=1
 key04=1
 
 [offset]
-; the offset is added to the redis value before being sent as OSC message
-; this option can be specified as number or as redis channel
+; the offset is added to the Redis value before being sent as OSC message
 ; the OSC values should be between 0 and 1
 key01=0
 key02=0
@@ -52,8 +43,7 @@ key03=0
 key04=0
 
 [output]
-; the keys here can have an arbitrary name, but should map those in the other sections
-; the keys must be lower-case
+; the keys here can have an arbitrary lower-case name, but should map those in the other sections
 key01=/1/faderA
 key02=/1/faderB
 key03=/1/faderC

--- a/module/outputosc/outputosc.py
+++ b/module/outputosc/outputosc.py
@@ -95,17 +95,6 @@ while True:
         else:
             val = [float(x) for x in val]
 
-        if patch.getint('compressor_expander', 'enable'):
-            # the compressor applies to all channels and must exist as float or redis key
-            lo = patch.getfloat('compressor_expander', 'lo')
-            hi = patch.getfloat('compressor_expander', 'hi')
-            if lo is None or hi is None:
-                if debug>1:
-                    print "cannot apply compressor/expander"
-            else:
-                # apply the compressor/expander
-                val = EEGsynth.compress(val, lo, hi)
-
         # the scale and offset options are channel specific
         scale  = patch.getfloat('scale', key1, default=1)
         offset = patch.getfloat('offset', key1, default=0)

--- a/module/rms/rms.ini
+++ b/module/rms/rms.ini
@@ -16,7 +16,7 @@ increase=launchcontrol.note073
 decrease=launchcontrol.note074
 recalibrate=launchcontrol.note075
 freeze=launchcontrol.note041      ; this should be a toggle button
-stepsize=0.10                     ; both button press and release might result in a message
+stepsize=0.10                     ; fractional amount to change the gain upon each button press
 
 [input]
 ; this specifies the channels from the FieldTrip buffer

--- a/module/smoothing/smoothing.ini
+++ b/module/smoothing/smoothing.ini
@@ -2,7 +2,7 @@
 debug=2
 
 [redis]
-hostname=synthpi.local
+hostname=localhost
 port=6379
 
 [smoothing]


### PR DESCRIPTION
it is still explicitly part of calibration (including disable/enable button and increase/decrease buttons)

it is also supported in postprocessing

it is not yet part of normalization 