### PR TITLE
Bugfixes and cleanup of code + adding timing output for debugging

### DIFF
--- a/module/cogito/README.md
+++ b/module/cogito/README.md
@@ -11,3 +11,4 @@ More info: http://www.ouunpo.com/eegsynth/?p=751
 Python 2.7.x
 numpy
 pandas
+h5py

--- a/module/cogito/cogito.ini
+++ b/module/cogito/cogito.ini
@@ -1,6 +1,10 @@
 [general]
-debug=1
+debug=2
 delay=0.05
+
+[redis]
+hostname=localhost
+port=6379
 
 [input_fieldtrip]
 hostname=localhost
@@ -18,34 +22,34 @@ port=1973
 2=F5
 3=F1
 4=F3
-5=FC1
-6=FC3
-7=FC5
-8=C1
-9=C3
-10=C5
-11=CP1
-12=CP3
-13=P3
-14=O9
-15=PO9
-16=P9
-17=AF4
-18=F6
-19=F2
-20=F4
-21=FC2
-22=FC4
-23=FC6
-24=C2
-25=C4
-26=C6
-27=CP2
-28=CP4
-29=P4
-30=O10
-31=PO10
-32=P10
+; 5=FC1
+; 6=FC3
+; 7=FC5
+; 8=C1
+; 9=C3
+; 10=C5
+; 11=CP1
+; 12=CP3
+; 13=P3
+; 14=O9
+; 15=PO9
+; 16=P9
+; 17=AF4
+; 18=F6
+; 19=F2
+; 20=F4
+; 21=FC2
+; 22=FC4
+; 23=FC6
+; 24=C2
+; 25=C4
+; 26=C6
+; 27=CP2
+; 28=CP4
+; 29=P4
+; 30=O10
+; 31=PO10
+; 32=P10
 
 [output_channel]
 ; this allows to specify the channel names in the output data stream

--- a/module/cogito/cogito.ini
+++ b/module/cogito/cogito.ini
@@ -60,6 +60,7 @@ window=1.0
 sample_rate=44100
 f_min=1
 f_max=45
+f_offset=300
 scaling=65536
 polyorder=10
 profileMin=1.0

--- a/module/cogito/cogito.py
+++ b/module/cogito/cogito.py
@@ -152,6 +152,7 @@ sample_rate         = patch.getfloat('cogito', 'sample_rate')
 window              = patch.getfloat('cogito', 'window')
 f_min               = patch.getfloat('cogito', 'f_min')
 f_max               = patch.getfloat('cogito', 'f_max')
+f_offset            = patch.getfloat('cogito', 'f_offset')
 scaling             = patch.getfloat('cogito', 'scaling')
 polyorder           = patch.getint('cogito', 'polyorder',None)
 profileMin          = patch.getfloat('cogito', 'profileMin')
@@ -214,8 +215,8 @@ while True:
     # signal = np.sin(t*f/sample_rate)*256
     # signal = np.zeros([sample_rate, 1])
 
-    # This (300) should not be hard-coded but in ini with explanation
-    tmp = [np.zeros(300)]
+    # Add offset to avoid LP filter on sound card
+    tmp = [np.zeros(int(f_offset))]
 
     for ch in range(nInputs):
         chan_time = time.time()

--- a/module/cogito/cogito.py
+++ b/module/cogito/cogito.py
@@ -27,6 +27,7 @@ import os
 import pandas as pd
 import sys
 import time
+import redis
 
 if hasattr(sys, 'frozen'):
     basis = sys.executable
@@ -99,16 +100,6 @@ output_number, output_channel = map(list, zip(*config.items('output_channel')))
 input_number = [int(number)-1 for number in input_number]
 output_number = [int(number)-1 for number in output_number]
 
-def sanitize(equation):
-    equation = equation.replace('(', '( ')
-    equation = equation.replace(')', ' )')
-    equation = equation.replace('+', ' + ')
-    equation = equation.replace('-', ' - ')
-    equation = equation.replace('*', ' * ')
-    equation = equation.replace('/', ' / ')
-    equation = equation.replace('  ', ' ')
-    return equation
-
 hdr_input = None
 start = time.time()
 while hdr_input is None:
@@ -129,10 +120,12 @@ nInputs = hdr_input.nChannels
 if len(hdr_input.labels) == 0:
     for i in range(nInputs):
         hdr_input.labels.append('{}'.format(i+1))
+
 # update the labels with the ones specified in the ini file
 for number, channel in zip(input_number, input_channel):
     if number < nInputs:
         hdr_input.labels[number] = channel
+
 # update the input channel specification
 input_number = range(nInputs)
 input_channel = hdr_input.labels
@@ -142,6 +135,7 @@ nOutputs = max(output_number)+1
 tmp = ['{}'.format(i+1) for i in range(nOutputs)]
 for number, channel in zip(output_number, output_channel):
     tmp[number] = channel
+
 # update the output channel specification
 output_number = range(nOutputs)
 output_channel = tmp
@@ -154,23 +148,17 @@ if debug > 0:
     for number, channel in zip(output_number, output_channel):
         print number, '=', channel
 
-sample_rate = patch.getfloat('cogito', 'sample_rate')
-window      = patch.getfloat('cogito', 'window')
-f_min       = patch.getfloat('cogito', 'f_min')
-f_max       = patch.getfloat('cogito', 'f_max')
-scaling     = patch.getfloat('cogito', 'scaling')
-try:
-    polyorder = patch.getint('cogito', 'polyorder')
-except:
-    polyorder = None
-
-profileMin = patch.getfloat('cogito', 'profileMin')
-profileMax = patch.getfloat('cogito', 'profileMax')
-profileCorrection = np.loadtxt('Dwingeloo-Transmitter-Profile.txt')
-profileCorrection = (1. - profileCorrection)*(profileMax-profileMin)
-profileCorrection += profileMin
-
-window = int(round(window*hdr_input.fSample))
+sample_rate         = patch.getfloat('cogito', 'sample_rate')
+window              = patch.getfloat('cogito', 'window')
+f_min               = patch.getfloat('cogito', 'f_min')
+f_max               = patch.getfloat('cogito', 'f_max')
+scaling             = patch.getfloat('cogito', 'scaling')
+polyorder           = patch.getint('cogito', 'polyorder',None)
+profileMin          = patch.getfloat('cogito', 'profileMin')
+profileMax          = patch.getfloat('cogito', 'profileMax')
+profileCorrection   = np.loadtxt('Dwingeloo-Transmitter-Profile.txt')
+profileCorrection   = (1. - profileCorrection)*(profileMax-profileMin) + profileMin
+window              = int(round(window*hdr_input.fSample))
 
 # FIXME these are in Hz, but should be mapped to frequency bins
 f_min = int(f_min)
@@ -200,7 +188,7 @@ else:
 
 print "STARTING COGITO STREAM"
 while True:
-    start = time.time();
+    start_time = time.time()
 
     while endsample>hdr_input.nSamples-1:
         # wait until there is enough data
@@ -209,57 +197,76 @@ while True:
         if (hdr_input.nSamples-1)<(endsample-window):
             print "Error: buffer reset detected"
             raise SystemExit
-        if (time.time()-start)>timeout:
+        if (time.time()-start_time)>timeout:
             print "Error: timeout while waiting for data"
             raise SystemExit
 
-    # determine the start of the actual processing
-    start = time.time();
-
     dat_input = ft_input.getData([begsample, endsample])
+
+    if debug > 1:
+        print 'time waiting for data: ' + str((time.time() - start_time) * 1000)
+
+    # determine the start of the actual processing
+    loop_time = time.time()
 
     # t = np.arange(sample_rate)
     # f = 440
     # signal = np.sin(t*f/sample_rate)*256
     # signal = np.zeros([sample_rate, 1])
 
+    # This (300) should not be hard-coded but in ini with explanation
     tmp = [np.zeros(300)]
 
     for ch in range(nInputs):
+        chan_time = time.time()
+
         original = copy(dat_input[:, ch])
-        # fit and subtract a 10th order polynomial
+
+        # fit and subtract a polynomial
         t = np.arange(0, len(original))
         if not(polyorder == None):
             p = np.polynomial.polynomial.polyfit(t, original, polyorder)
             original = original - np.polynomial.polynomial.polyval(t, p)
 
         # One
-        channel = [np.ones(1)*scaling/250.]
+        channel = [np.ones(1)*scaling/sample_rate]
 
         # Spectrum
-        fourier = np.fft.rfft(original, 250)[f_min:f_max]
+        fourier = np.fft.rfft(original, int(sample_rate))[f_min:f_max]
         channel.append(fourier)
 
         # Positions
         mask = np.zeros(30)
-        mask[(positions[ch][0]-1):positions[ch][0]] = scaling/250
-        mask[(10+positions[ch][1]-1):(10+positions[ch][1])] = scaling/250
-        mask[(20+positions[ch][2]-1):(20+positions[ch][2])] = scaling/250
+        mask[(positions[ch][0]-1):positions[ch][0]] = scaling/int(sample_rate)
+        mask[(10+positions[ch][1]-1):(10+positions[ch][1])] = scaling/int(sample_rate)
+        mask[(20+positions[ch][2]-1):(20+positions[ch][2])] = scaling/int(sample_rate)
         channel.append(mask)
 
         # Sum of all the parts
         convert = np.concatenate(channel) * profileCorrection[ch]
         tmp.append(convert)
 
+        if debug > 1:
+            print 'time to process single channel: ' + str((time.time() - chan_time) * 1000)
+
+    signal_time = time.time()
     signal = np.fft.irfft(np.concatenate(tmp), int(sample_rate))
     dat_output = np.atleast_2d(signal).T.astype(np.float32)
 
+    if debug > 1:
+        print 'time to inverse FFT: ' + str((time.time() - signal_time) * 1000)
+
+    write_time = time.time()
+
     # write the data to the output buffer
     ft_output.putData(dat_output)
+
+    if debug > 1:
+        print 'time to write data to buffer: ' + str((time.time() - write_time) * 1000)
 
     # increment the counters for the next loop
     begsample += window
     endsample += window
 
-    if debug>0:
-	print "processed", window, "samples in", (time.time()-start)*1000, "ms"
+    if debug > 0:
+	    print "processed", window, "samples in", (time.time()-loop_time)*1000, "ms"

--- a/module/cogito/gtec2wav.py
+++ b/module/cogito/gtec2wav.py
@@ -15,7 +15,7 @@
 # ==============================================================================
 
 import h5py
-import matplotlib.pyplot as plt
+# import matplotlib.pyplot as plt
 import pandas as pd
 from scipy import signal
 import numpy as np
@@ -23,6 +23,7 @@ import wave
 import struct
 
 filename = "RecordSession_YYY.MM.DD_HH.MM.SS.hdf5"
+filename = "../../data/test.hdf5"
 
 profileMin=1.0
 profileMax=1.5


### PR DESCRIPTION
@deep-introspection @robertoostenveld:

It takes about 1.7 seconds to write one second to the second (wav) buffer on my new super-fast Ubuntu laptop. Debugging the timings, its clear this is taken up by writing to the buffer (1.6 seconds). Is this the same problem we encountered before, i.e. the localhost loopback?

If so, this might be the case with the postprocessing module as well?
