### PR TITLE
reimplemented the sequencer

### DIFF
--- a/module/sequencer/sequencer.ini
+++ b/module/sequencer/sequencer.ini
@@ -8,8 +8,7 @@ port=6379
 
 [sequence]
 ; these are some sequences from http://www.guitarland.com/Music10/FGA/LectureMIDIscales.html
-;pattern0  =   0   3   5   6   7  10  12          ; minor_blues
-pattern0  =   0 x 1 x 2 x 3 x 4 x
+pattern0  =   0   3   5   6   7  10  12          ; minor_blues
 pattern1  =   0   2   3   4   7   9  12          ; major_blues
 pattern2  =   0   2   3   5   7   9  10  12      ; dorian
 pattern3  =   0   1   3   5   7   8  10  12      ; phrygian

--- a/module/sequencer/sequencer.ini
+++ b/module/sequencer/sequencer.ini
@@ -1,5 +1,6 @@
 [general]
 debug=2
+delay=0.1
 
 [redis]
 hostname=localhost
@@ -7,7 +8,8 @@ port=6379
 
 [sequence]
 ; these are some sequences from http://www.guitarland.com/Music10/FGA/LectureMIDIscales.html
-pattern0  =   0   3   5   6   7  10  12          ; minor_blues
+;pattern0  =   0   3   5   6   7  10  12          ; minor_blues
+pattern0  =   0 x 1 x 2 x 3 x 4 x
 pattern1  =   0   2   3   4   7   9  12          ; major_blues
 pattern2  =   0   2   3   5   7   9  10  12      ; dorian
 pattern3  =   0   1   3   5   7   8  10  12      ; phrygian
@@ -20,36 +22,50 @@ pattern9  =   0   1   3   4   6   8  10  12      ; super_locrian
 pattern10 =   0   3   5   7  10  12              ; minor_pentatonic
 pattern11 =   0   2   4   7   9  12              ; major_pentatonic
 pattern12 =   0   2   3   5   6   8   9  11  12  ; whole_half_diminished
+
 ; these are some short test sequences that don't sound too bad
-;pattern0  =  0   4   0   7
-;pattern1  =  0   4   7   9  10   9   7   4
-;pattern2  =  5  10  13  10
-;pattern3  =  5  13  12  10
+pattern20  =  0   4   0   7
+pattern21  =  0   4   7   9  10   9   7   4
+pattern22  =  5  10  13  10
+pattern23  =  5  13  12  10
+
+; these are some sequences for the Volca Beats
+pattern30  = 36  38  38  38  ; kick snare snare snare
 
 ; these get the pitch from 4, 8 or 16 knobs of the Launch Control XL (row 2 and 3)
-pattern13 = launchcontrol.control029 launchcontrol.control030 launchcontrol.control031 launchcontrol.control032
-pattern14 = launchcontrol.control029 launchcontrol.control030 launchcontrol.control031 launchcontrol.control032 launchcontrol.control033 launchcontrol.control034 launchcontrol.control035 launchcontrol.control036
-pattern15 = launchcontrol.control029 launchcontrol.control030 launchcontrol.control031 launchcontrol.control032 launchcontrol.control033 launchcontrol.control034 launchcontrol.control035 launchcontrol.control036 launchcontrol.control049 launchcontrol.control050 launchcontrol.control051 launchcontrol.control052 launchcontrol.control053 launchcontrol.control054 launchcontrol.control055 launchcontrol.control056
+pattern40 = launchcontrol.control029 launchcontrol.control030 launchcontrol.control031 launchcontrol.control032
+pattern41 = launchcontrol.control029 launchcontrol.control030 launchcontrol.control031 launchcontrol.control032 launchcontrol.control033 launchcontrol.control034 launchcontrol.control035 launchcontrol.control036
+pattern42 = launchcontrol.control029 launchcontrol.control030 launchcontrol.control031 launchcontrol.control032 launchcontrol.control033 launchcontrol.control034 launchcontrol.control035 launchcontrol.control036 launchcontrol.control049 launchcontrol.control050 launchcontrol.control051 launchcontrol.control052 launchcontrol.control053 launchcontrol.control054 launchcontrol.control055 launchcontrol.control056
+
+; the notes in the sequence are scaled and offset by this amount
+scale=1
+offset=0
 
 [control]
 pattern=launchcontrol.control013    ; one of the patterns listed above
 rate=launchcontrol.control014       ; in beats per minute
 transpose=launchcontrol.control015
+steps=4
+adjust=0
 
 [scale]
 ; this applies to the control signals, which are by default 0-1 in Redis
 pattern=127
 rate=127
-transpose=1
+transpose=127
+steps=1
+adjust=1
 
 [offset]
 ; this applies to the control signals, which are by default 0-1 in Redis
 pattern=0
 rate=0
-transpose=-0.5
+transpose=-64
+steps=0
+adjust=0
 
 [output]
-; the result is writen to Redis as "sequencer.note" with the subsequent values of the sequence
+; the notes in the sequence will be published to Redis as "sequencer.note" with the corresponding value
 prefix=sequencer
 
 ; the scale and offset are used to map the values from the sequence to Redis

--- a/module/sequencer/sequencer.py
+++ b/module/sequencer/sequencer.py
@@ -4,7 +4,7 @@
 #
 # Sequencer is part of the EEGsynth project (https://github.com/eegsynth/eegsynth)
 #
-# Copyright (C) 2017 EEGsynth project
+# Copyright (C) 2017-2018 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,9 +22,11 @@
 import ConfigParser # this is version 2.x specific,on version 3.x it is called "configparser" and has a different API
 import argparse
 import math
+import numpy as np
 import os
 import redis
 import sys
+import threading
 import time
 
 if hasattr(sys, 'frozen'):
@@ -60,115 +62,220 @@ del config
 # this determines how much debugging information gets printed
 debug = patch.getint('general','debug')
 
-# these scale and offset parameters are used to map Redis values to internal values
-scale_pattern    = patch.getfloat('scale',  'pattern',   default=127) # internal MIDI values
-scale_transpose  = patch.getfloat('scale',  'transpose', default=127) # internal MIDI values
-scale_rate       = patch.getfloat('scale',  'rate',      default=127) # beats per minute
-offset_pattern   = patch.getfloat('offset', 'pattern',   default=0)
-offset_transpose = patch.getfloat('offset', 'transpose', default=0)
-offset_rate      = patch.getfloat('offset', 'rate',      default=0)
+# this can be used to selectively show parameters that have changed
+previous = {}
+def show_change(key, val):
+    if (key in previous and previous[key]!=val) or (key not in previous):
+        print key, "=", val
+    previous[key] = val
 
-# the output scale and offset are used to map the internal MIDI values to Redis values
-output_scale  = patch.getfloat('output', 'scale', default=0.00787401574803149606)
-output_offset = patch.getfloat('output', 'offset', default=0)
+# this is to prevent two threads accesing a variable at the same time
+lock = threading.Lock()
+
+clock = []
+for iteration in range(24):
+    clock.append(threading.Event())
+
+class ClockThread(threading.Thread):
+    def __init__(self):
+        threading.Thread.__init__(self)
+        self.running = True
+        self.rate = 60              # the rate is in bpm, i.e. quarternotes per minute
+    def setRate(self, rate):
+        with lock:
+            self.rate = rate
+    def stop(self):
+        self.running = False
+    def run(self):
+        slip = 0
+        while self.running:
+            now    = time.time()
+            delay  = 60/self.rate   # the rate is in bpm
+            delay -= slip           # correct for the slip from the previous iteration
+            jiffy = delay/(24)
+            if debug>1:
+                print 'clock step'
+            for iteration in range(24):
+                clock[iteration].set()
+                clock[iteration].clear()
+                if jiffy>0:
+                    time.sleep(jiffy)
+            # the actual time used in this loop will be slightly different than desired
+            # this will be corrected on the next iteration
+            slip = time.time() - now - delay
+
+class SequenceThread(threading.Thread):
+    def __init__(self):
+        threading.Thread.__init__(self)
+        self.running   = True
+        self.steps     = 0
+        self.adjust    = 0
+        self.sequence  = []
+        self.transpose = 0
+        self.current   = 0
+    def setSteps(self, steps):
+        with lock:
+            self.steps = steps
+    def setAdjust(self, adjust):
+        with lock:
+            self.adjust = adjust
+    def setSequence(self, sequence):
+        with lock:
+            self.sequence = sequence
+    def setTranspose(self, transpose):
+        with lock:
+            self.transpose = transpose
+    def stop(self):
+        self.running = False
+    def run(self):
+        while self.running:
+            if self.steps in [1, 2, 3, 4, 6, 8, 12, 24] and len(self.sequence):
+                with lock:
+                    step = np.mod(np.arange(0, 24, 24/self.steps) + self.adjust, 24).astype(int).tolist()
+                if debug>1:
+                    print "sequence step =", step
+
+                for tick in [clock[i] for i in step]:
+                    # the note can be a value or a string pointing to a Redis channel
+                    with lock:
+                        if len(self.sequence):
+                            note = self.sequence[np.mod(self.current, len(self.sequence))]
+                        else:
+                            note = None
+                    note = r.get(note) or note
+                    try:
+                        note = float(note)
+                    except TypeError:
+                        # this happens if it is not a number or a string, e.g. None
+                        note = None
+                    except ValueError:
+                        # this happens if it is a string that cannot be converted
+                        note = None
+                    if note:
+                        # map the Redis values to the internally used values
+                        note = EEGsynth.rescale(note, slope=pattern_scale, offset=pattern_offset)
+                        note = note + self.transpose
+                        # map the internally used values to Redis values
+                        val = EEGsynth.rescale(note, slope=output_scale, offset=output_offset)
+                    if debug>1:
+                        print 'sequence note =', note
+                    tick.wait()             # wait for synchronization with the clock thread
+                    if note:
+                        r.set(key, val)     # send it as control value
+                        r.publish(key, val) # send it as trigger
+                    self.current += 1
+            else:
+                # if self.steps is not appropriate
+                time.sleep(patch.getfloat('general', 'delay'))
+
+# create and start the thread that manages the clock
+clockthread = ClockThread()
+clockthread.start()
+
+# create and start the thread for the output
+sequencethread = SequenceThread()
+sequencethread.start()
+
+# these scale and offset parameters are used to map Redis values to internal values
+scale_pattern    = patch.getfloat('scale', 'pattern',   default=127.) # internal MIDI values
+scale_rate       = patch.getfloat('scale', 'rate',      default=127.) # beats per minute
+scale_transpose  = patch.getfloat('scale', 'transpose', default=127.) # internal MIDI values
+scale_steps      = patch.getfloat('scale', 'steps',     default=1.)
+scale_adjust     = patch.getfloat('scale', 'adjust',    default=1.)
+
+offset_pattern   = patch.getfloat('offset', 'pattern',   default=0.)
+offset_rate      = patch.getfloat('offset', 'rate',      default=0.)
+offset_transpose = patch.getfloat('offset', 'transpose', default=0.)
+offset_steps     = patch.getfloat('offset', 'steps',     default=0.)
+offset_adjust    = patch.getfloat('offset', 'adjust',    default=0.)
+
+# the output scale and offset are used to map the internal values to Redis values
+pattern_scale  = patch.getfloat('output', 'scale', default=127.)
+pattern_offset = patch.getfloat('output', 'offset', default=0.)
+
+# the output scale and offset are used to map the internal values to Redis values
+output_scale  = patch.getfloat('output', 'scale', default=1./127)
+output_offset = patch.getfloat('output', 'offset', default=0.)
+
+# the notes will be sent to Redis using this key
+key = "{}.note".format(patch.getstring('output','prefix'))
 
 if debug>0:
-    print 'scale_pattern    =', scale_pattern
-    print 'scale_transpose  =', scale_transpose
-    print 'scale_rate       =', scale_rate
-    print 'offset_pattern   =', offset_pattern
-    print 'offset_transpose =', offset_transpose
-    print 'offset_rate      =', offset_rate
-
-previous_pattern   = -1
-previous_transpose = -1
-previous_rate      = -1
-
-# this is just to get started
-sequence = '0'
-
+    show_change('scale_pattern',    scale_pattern)
+    show_change('scale_transpose',  scale_transpose)
+    show_change('scale_rate',       scale_rate)
+    show_change('scale_steps',      scale_steps)
+    show_change('scale_adjust',     scale_adjust)
+    show_change('offset_pattern',   offset_pattern)
+    show_change('offset_transpose', offset_transpose)
+    show_change('offset_rate',      offset_rate)
+    show_change('offset_steps',     offset_steps)
+    show_change('offset_adjust',    offset_adjust)
 
 try:
     while True:
+        # measure the time to correct for the slip
+        now = time.time()
 
+        if debug>0:
+            print 'loop'
+
+        # the pattern should be a integer between 0 and 127
+        pattern = patch.getfloat('control','pattern', default=0)
+        pattern = EEGsynth.rescale(pattern, slope=scale_pattern, offset=offset_pattern)
+        pattern = int(pattern)
+
+        # use a default rate of 90 bpm
+        rate = patch.getfloat('control','rate', default=90./127)
+        rate = EEGsynth.rescale(rate, slope=scale_rate, offset=offset_rate)
+        # ensure that the rate is within meaningful limits
+        rate = EEGsynth.limit(rate, 40., 240.)
+
+        # use a default transposition of 48
+        transpose = patch.getfloat('control','transpose', default=48./127)
+        transpose = EEGsynth.rescale(transpose, slope=scale_transpose, offset=offset_transpose)
+
+        steps = patch.getfloat('control', 'steps', default=1)
+        steps = EEGsynth.rescale(steps, slope=scale_steps, offset=offset_steps)
+        steps = int(steps)
+
+        adjust = patch.getfloat('control', 'adjust', default=0)
+        adjust = EEGsynth.rescale(adjust, slope=scale_adjust, offset=offset_adjust)
+        adjust = int(adjust)
+
+        # get the corresponding sequence as a single string
+        try:
+            sequence = patch.getstring('sequence',"pattern{:d}".format(pattern))
+        except:
+            sequence = ''
         if sequence.find(",") > -1:
             separator = ","
         else:
             separator = " "
+        # convert the single string into a list
+        sequence = sequence.split(separator)
+        # remove the empty items, e.g. spaces
+        sequence = filter(len, sequence)
 
-        for note in sequence.split(separator):
-            # the note can be a value or a string pointing to a Redis channel
-            try:
-                note = float(note)
-            except:
-                # it seems to be a string pointing to a Redis channel
-                try:
-                    note = float(r.get(note))
-                except:
-                    # the Redis channel does not exist or is empty
-                    if debug>1:
-                        print "note", note, "is not available"
-                    note = 0
+        if debug>0:
+            # show the parameters whose value has changed
+            show_change("pattern",   pattern)
+            show_change("sequence",  sequence)
+            show_change("rate",      rate)
+            show_change("transpose", transpose)
+            show_change("steps",     steps)
+            show_change("adjust",    adjust)
 
-            # the pattern should be an integer between 0 and 127
-            pattern = patch.getfloat('control','pattern', default=0)
-            pattern = EEGsynth.rescale(pattern, slope=scale_pattern, offset=offset_pattern)
-            pattern = int(pattern)
+        sequencethread.setSequence(sequence)
+        clockthread.setRate(rate)
+        sequencethread.setTranspose(transpose)
+        sequencethread.setSteps(steps)
+        sequencethread.setAdjust(adjust)
 
-            if pattern!=previous_pattern:
-                if debug>0:
-                    print 'pattern =', pattern
-                previous_pattern = pattern
-                # get the corresponding sequence
-                try:
-                    sequence = patch.getstring('sequence',"pattern{:d}".format(pattern))
-                except:
-                    sequence = '0'
-                # immediately start playing the new sequence
-                break
-
-            # use a default transposition of 48
-            transpose = patch.getfloat('control','transpose', default=48./127)
-            transpose = EEGsynth.rescale(transpose, slope=scale_transpose, offset=offset_transpose)
-
-            if transpose!=previous_transpose:
-                if debug>0:
-                    print 'transpose =',  transpose
-                previous_transpose = transpose
-
-            # use a default rate of 90 bpm
-            rate = patch.getfloat('control','rate', default=90./127)
-            rate = EEGsynth.rescale(rate, slope=scale_rate, offset=offset_rate)
-
-            if rate!=previous_rate:
-                if debug>0:
-                    print 'rate =',  rate
-                previous_rate = rate
-
-            # assume that the rate value is between 0 and 127, map it exponentially from 60 to 600
-            # it should not get too low, otherwise the code with the sleep below becomes unresponsive
-            rate = 60. * math.exp(math.log(10) * rate/127)
-
-            if debug>2:
-                print '-----------------------'
-                print 'pattern   =', pattern
-                print 'rate      =', rate
-                print 'transpose =', transpose
-                print 'note      =', note
-
-            key = "{}.note".format(patch.getstring('output','prefix'))
-            val = note + transpose
-
-            # map the internally used values to Redis values
-            val = EEGsynth.rescale(val, slope=output_scale, offset=output_offset)
-
-            if debug>1:
-                print key, '=', val
-
-            r.set(key, val)     # send it as control value
-            r.publish(key, val) # send it as trigger
-
-            time.sleep(60./rate)
+        elapsed = time.time() - now
+        naptime = patch.getfloat('general', 'delay') - elapsed
+        if naptime>0:
+            time.sleep(naptime)
 
 except KeyboardInterrupt:
     try:
@@ -177,3 +284,10 @@ except KeyboardInterrupt:
         r.publish(key,0)
     except:
         pass
+    print "Closing threads"
+    sequencethread.stop()
+    sequencethread.join()
+    # the thread that manages the clock should be stopped the last
+    clockthread.stop()
+    clockthread.join()
+    sys.exit()

--- a/module/synchronization/synchronization.ini
+++ b/module/synchronization/synchronization.ini
@@ -54,5 +54,5 @@ multiply=-2.015748031495
 adjust=-64
 
 [output]
-; the trigger events will be published to Redis as "synchronization"
-channel=synchronization
+; the trigger will be published to Redis as "synchronization.note"
+prefix=synchronization


### PR DESCRIPTION
with a same internal clock and synchronization mechanism as in the synchronization module. It now has two threads that handle the actual core business, and the main loop is just checking the parameters.

It still should be extended with an option for synchronizing with an external clock.

```
clock=internal  ; or a Redis key
```

The idea is that the synchronization module (which does some quite fancy timing) should also be able to drive the sequence. This is to be implemented using a pubsub channel in Redis.

 