### PR TITLE
use 2to3 to convert the Python 2.7 to Python 3.x

### DIFF
--- a/lib/EDF.py
+++ b/lib/EDF.py
@@ -357,8 +357,8 @@ class EDFReader():
 if False:
     file_in = EDFReader()
     file_in.open('/Users/roboos/day 01[10.03].edf')
-    print file_in.readSamples(0, 0, 0)
-    print file_in.readSamples(0, 0, 128)
+    print(file_in.readSamples(0, 0, 0))
+    print(file_in.readSamples(0, 0, 128))
 
 
 if False:

--- a/lib/EEGsynth.py
+++ b/lib/EEGsynth.py
@@ -1,4 +1,4 @@
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import mido
 import os
 import sys
@@ -12,7 +12,7 @@ try:
     import OSC
 except:
     # this means that midiosc is not supported as midi backend
-    print "Warning: pyOSC not found"
+    print("Warning: pyOSC not found")
 
 ###################################################################################################
 class midiwrapper():
@@ -26,11 +26,11 @@ class midiwrapper():
         self.outputport = None
         try:
             self.backend = config.get('midi', 'backend')
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             self.backend = 'mido'
         try:
             self.debug = config.getint('general', 'debug')
-        except ConfigParser.NoOptionError:
+        except configparser.NoOptionError:
             self.debug = 0
 
     def open_output(self):
@@ -42,22 +42,22 @@ class midiwrapper():
                 print('-------------------------')
             try:
                 self.outputport  = mido.open_output(self.config.get('midi', 'device'))
-                print "Connected to MIDI output"
+                print("Connected to MIDI output")
             except:
-                print "Error: cannot connect to MIDI output"
+                print("Error: cannot connect to MIDI output")
                 raise RuntimeError("Error: cannot connect to MIDI output")
 
         elif self.backend == 'midiosc':
             try:
                 self.outputport = OSC.OSCClient()
                 self.outputport.connect((self.config.get('midi','hostname'), self.config.getint('midi','port')))
-                print "Connected to OSC server"
+                print("Connected to OSC server")
             except:
-                print "Error: cannot connect to OSC server"
+                print("Error: cannot connect to OSC server")
                 raise RuntimeErrror("cannot connect to OSC server")
 
         else:
-            print 'Error: unsupported backend: ' + self.backend
+            print('Error: unsupported backend: ' + self.backend)
             raise RuntimeError('unsupported backend: ' + self.backend)
 
     def send(self, mido_msg):
@@ -92,7 +92,7 @@ class midiwrapper():
             # send the OSC message, the receiving "midiosc" application will convert it back to MIDI
             self.outputport.send(osc_msg)
         else:
-            print 'Error: unsupported backend: ' + self.backend
+            print('Error: unsupported backend: ' + self.backend)
             raise RuntimeError('unsupported backend: ' + self.backend)
 
 
@@ -270,7 +270,7 @@ class patch():
         self.redis.set(item, val)      # set it as control channel
         self.redis.publish(item, val)  # send it as trigger
         if debug:
-            print item, '=', val
+            print(item, '=', val)
         if duration > 0:
             # switch off after a certain amount of time
             threading.Timer(duration, self.setvalue, args=[item, 0.]).start()
@@ -388,24 +388,24 @@ def initialize_online_filter(fsample, highpass, lowpass, order, x, axis=-1):
 
     if not(highpass is None) and not(lowpass is None) and highpass>=lowpass:
         # totally blocking all signal
-        print 'using NULL filter', [highpass, lowpass]
+        print('using NULL filter', [highpass, lowpass])
         b = np.zeros(window)
         a = np.ones(1)
     elif not(lowpass is None) and (highpass is None):
-        print 'using lowpass filter', [highpass, lowpass]
+        print('using lowpass filter', [highpass, lowpass])
         b = firwin(order, cutoff = lowpass, window = filtwin, pass_zero = True)
         a = np.ones(1)
     elif not(highpass is None) and (lowpass is None):
-        print 'using highpass filter', [highpass, lowpass]
+        print('using highpass filter', [highpass, lowpass])
         b = firwin(order, cutoff = highpass, window = filtwin, pass_zero = False)
         a = np.ones(1)
     elif not(highpass is None) and not(lowpass is None):
-        print 'using bandpass filter', [highpass, lowpass]
+        print('using bandpass filter', [highpass, lowpass])
         b = firwin(order, cutoff = [highpass, lowpass], window = filtwin, pass_zero = False)
         a = np.ones(1)
     else:
         # no filtering at all
-        print 'using IDENTITY filter', [highpass, lowpass]
+        print('using IDENTITY filter', [highpass, lowpass])
         b = np.ones(1)
         a = np.ones(1)
 

--- a/lib/FieldTrip.py
+++ b/lib/FieldTrip.py
@@ -550,36 +550,36 @@ if __name__ == "__main__":
         try:
             port = int(sys.argv[2])
         except:
-            print ('Error: second argument (%s) must be a valid (=integer)'
-                   ' port number' % sys.argv[2])
+            print(('Error: second argument (%s) must be a valid (=integer)'
+                   ' port number' % sys.argv[2]))
             sys.exit(1)
 
     ftc = Client()
 
-    print 'Trying to connect to buffer on %s:%i ...' % (hostname, port)
+    print('Trying to connect to buffer on %s:%i ...' % (hostname, port))
     ftc.connect(hostname, port)
 
-    print '\nConnected - trying to read header...'
+    print('\nConnected - trying to read header...')
     H = ftc.getHeader()
 
     if H is None:
-        print 'Failed!'
+        print('Failed!')
     else:
-        print H
-        print H.labels
+        print(H)
+        print(H.labels)
 
         if H.nSamples > 0:
-            print '\nTrying to read last sample...'
+            print('\nTrying to read last sample...')
             index = H.nSamples - 1
             D = ftc.getData([index, index])
-            print D
+            print(D)
 
         if H.nEvents > 0:
-            print '\nTrying to read (all) events...'
+            print('\nTrying to read (all) events...')
             E = ftc.getEvents()
             for e in E:
-                print e
+                print(e)
 
-    print ftc.poll()
+    print(ftc.poll())
 
     ftc.disconnect()

--- a/module/accelerometer/accelerometer.py
+++ b/module/accelerometer/accelerometer.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser
+import configparser
 import argparse
 import mne
 import numpy as np
@@ -45,14 +45,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -68,31 +68,31 @@ try:
     ftc_host = patch.getstring('fieldtrip','hostname')
     ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ftc = FieldTrip.Client()
     ftc.connect(ftc_host, ftc_port)
     if debug>0:
-        print "Connected to FieldTrip buffer"
+        print("Connected to FieldTrip buffer")
 except:
-    print "Error: cannot connect to FieldTrip buffer"
+    print("Error: cannot connect to FieldTrip buffer")
     exit()
 
 hdr_input = None
 start = time.time()
 while hdr_input is None:
     if debug>0:
-        print "Waiting for data to arrive..."
+        print("Waiting for data to arrive...")
     if (time.time()-start)>timeout:
-        print "Error: timeout while waiting for data"
+        print("Error: timeout while waiting for data")
         raise SystemExit
     hdr_input = ftc.getHeader()
     time.sleep(0.2)
 
 if debug>0:
-    print "Data arrived"
+    print("Data arrived")
 if debug>1:
-    print hdr_input
-    print hdr_input.labels
+    print(hdr_input)
+    print(hdr_input.labels)
 
 # get the processing arameters
 window = int(patch.getfloat('processing','window') * hdr_input.fSample) # expressed in samples
@@ -113,12 +113,12 @@ while True:
 
     hdr_input = ftc.getHeader()
     if (hdr_input.nSamples-1)<endsample:
-        print "Error: buffer reset detected"
+        print("Error: buffer reset detected")
         raise SystemExit
     if hdr_input.nSamples < window:
         # there are not yet enough samples in the buffer
         if debug>0:
-            print "Waiting for data..."
+            print("Waiting for data...")
         continue
 
     # get the most recent data segment
@@ -139,4 +139,4 @@ while True:
         printval.append(val)
 
     if debug>1:
-        print printval
+        print(printval)

--- a/module/audio2ft/audio2ft.py
+++ b/module/audio2ft/audio2ft.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser  # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -46,14 +46,14 @@ parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder,
                                                             os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -67,13 +67,13 @@ try:
     ftc_host = patch.getstring('fieldtrip', 'hostname')
     ftc_port = patch.getint('fieldtrip', 'port')
     if debug > 0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ft_output = FieldTrip.Client()
     ft_output.connect(ftc_host, ftc_port)
     if debug > 0:
-        print "Connected to output FieldTrip buffer"
+        print("Connected to output FieldTrip buffer")
 except:
-    print "Error: cannot connect to output FieldTrip buffer"
+    print("Error: cannot connect to output FieldTrip buffer")
     exit()
 
 device      = patch.getint('audio', 'device')
@@ -82,26 +82,26 @@ blocksize   = patch.getint('audio', 'blocksize', default=1024)
 nchans      = patch.getint('audio', 'nchans', default=2)
 
 if debug > 0:
-    print "rate", rate
-    print "nchans", nchans
-    print "blocksize", blocksize
+    print("rate", rate)
+    print("nchans", nchans)
+    print("blocksize", blocksize)
 
 p = pyaudio.PyAudio()
 
-print '------------------------------------------------------------------'
+print('------------------------------------------------------------------')
 info = p.get_host_api_info_by_index(0)
-print info
-print '------------------------------------------------------------------'
+print(info)
+print('------------------------------------------------------------------')
 for i in range(info.get('deviceCount')):
     if p.get_device_info_by_host_api_device_index(0, i).get('maxInputChannels') > 0:
-        print "Input  Device id ", i, " - ", p.get_device_info_by_host_api_device_index(0, i).get('name')
+        print("Input  Device id ", i, " - ", p.get_device_info_by_host_api_device_index(0, i).get('name'))
     if p.get_device_info_by_host_api_device_index(0, i).get('maxOutputChannels') > 0:
-        print "Output Device id ", i, " - ", p.get_device_info_by_host_api_device_index(0, i).get('name')
-print '------------------------------------------------------------------'
+        print("Output Device id ", i, " - ", p.get_device_info_by_host_api_device_index(0, i).get('name'))
+print('------------------------------------------------------------------')
 devinfo = p.get_device_info_by_index(device)
-print "Selected device is", devinfo['name']
-print devinfo
-print '------------------------------------------------------------------'
+print("Selected device is", devinfo['name'])
+print(devinfo)
+print('------------------------------------------------------------------')
 
 stream = p.open(format=pyaudio.paInt16,
                 channels=nchans,
@@ -115,7 +115,7 @@ ft_output.putHeader(nchans, float(rate), FieldTrip.DATATYPE_INT16)
 startfeedback = time.time()
 countfeedback = 0
 
-print "STARTING STREAM"
+print("STARTING STREAM")
 while True:
 
     # measure the time that it takes
@@ -131,10 +131,10 @@ while True:
     countfeedback += blocksize
 
     if debug > 1:
-        print "streamed", blocksize, "samples in", (time.time() - start) * 1000, "ms"
+        print("streamed", blocksize, "samples in", (time.time() - start) * 1000, "ms")
     elif debug > 0 and countfeedback >= rate:
         # this gets printed approximately once per second
-        print "streamed", countfeedback, "samples in", (time.time() - startfeedback) * 1000, "ms"
+        print("streamed", countfeedback, "samples in", (time.time() - startfeedback) * 1000, "ms")
         startfeedback = time.time()
         countfeedback = 0
 

--- a/module/bitalino2ft/bitalino2ft.py
+++ b/module/bitalino2ft/bitalino2ft.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -46,14 +46,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -67,13 +67,13 @@ try:
     ftc_host = patch.getstring('fieldtrip','hostname')
     ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ft_output = FieldTrip.Client()
     ft_output.connect(ftc_host, ftc_port)
     if debug>0:
-        print "Connected to output FieldTrip buffer"
+        print("Connected to output FieldTrip buffer")
 except:
-    print "Error: cannot connect to output FieldTrip buffer"
+    print("Error: cannot connect to output FieldTrip buffer")
     exit()
 
 device    = patch.getstring('bitalino', 'device')
@@ -84,10 +84,10 @@ nchans    = len(channels)
 batterythreshold = patch.getint('bitalino', 'batterythreshold', default=30)
 
 if debug > 0:
-    print "fsample", fsample
-    print "channels", channels
-    print "nchans", nchans
-    print "blocksize", blocksize
+    print("fsample", fsample)
+    print("channels", channels)
+    print("nchans", nchans)
+    print("blocksize", blocksize)
 
 # switch from one-offset to zero-offset
 for i in range(nchans):
@@ -100,11 +100,11 @@ try:
     # Connect to BITalino
     device = BITalino(device)
 except:
-    print "Error: cannot connect to BITalino"
+    print("Error: cannot connect to BITalino")
     exit()
 
 # Read BITalino version
-print(device.version())
+print((device.version()))
 
 # Set battery threshold
 device.battery(batterythreshold)
@@ -119,7 +119,7 @@ device.trigger(digitalOutput)
 startfeedback = time.time()
 countfeedback = 0
 
-print "STARTING STREAM"
+print("STARTING STREAM")
 while True:
 
     # measure the time that it takes
@@ -135,10 +135,10 @@ while True:
     countfeedback += blocksize
 
     if debug>1:
-        print "streamed", blocksize, "samples in", (time.time()-start)*1000, "ms"
+        print("streamed", blocksize, "samples in", (time.time()-start)*1000, "ms")
     elif debug>0 and countfeedback>=fsample:
         # this gets printed approximately once per second
-        print "streamed", countfeedback, "samples in", (time.time()-startfeedback)*1000, "ms"
+        print("streamed", countfeedback, "samples in", (time.time()-startfeedback)*1000, "ms")
         startfeedback = time.time();
         countfeedback = 0
 

--- a/module/calibration/calibration.py
+++ b/module/calibration/calibration.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from numpy import log, log2, log10, exp, power, sqrt, mean, median, var, std
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -47,14 +47,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -77,7 +77,7 @@ while True:
     start = time.time()
 
     # update with current data
-    for chanindx,chanstr in zip(range(numchannel), inputlist):
+    for chanindx,chanstr in zip(list(range(numchannel)), inputlist):
         try:
             chanval = patch.getfloat('input', chanstr)
         except:
@@ -94,7 +94,7 @@ while True:
             hi = patch.getfloat('compressor_expander', 'hi')
             if lo is None or hi is None:
                 if debug>1:
-                    print "cannot apply compressor/expander"
+                    print("cannot apply compressor/expander")
             else:
                 # apply the compressor/expander
                 chanval = EEGsynth.compress(chanval, lo, hi)
@@ -108,7 +108,7 @@ while True:
 
         value[chanindx] = chanval
 
-    for chanindx,chanstr in zip(range(numchannel), inputlist):
+    for chanindx,chanstr in zip(list(range(numchannel)), inputlist):
         for channel in range(numchannel):
             key = prefix +  "." + chanstr
             val = value[chanindx]

--- a/module/clockdivider/clockdivider.py
+++ b/module/clockdivider/clockdivider.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser  # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import os
 import redis
@@ -42,14 +42,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -98,7 +98,7 @@ trigger = []
 for chan in channel:
     for div in divider:
         trigger.append(TriggerThread(chan, div))
-        print "d%d.%s" % (div, chan)
+        print("d%d.%s" % (div, chan))
 
 # start the thread for each of the triggers
 for thread in trigger:
@@ -108,10 +108,10 @@ try:
     while True:
         time.sleep(1)
         if debug > 0:
-            print "count =", count / len(divider)
+            print("count =", count / len(divider))
 
 except KeyboardInterrupt:
-    print "Closing threads"
+    print("Closing threads")
     for thread in trigger:
         thread.stop()
     r.publish('CLOCKDIVIDER_UNBLOCK', 1)

--- a/module/clockmultiplier/clockmultiplier.py
+++ b/module/clockmultiplier/clockmultiplier.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser  # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import os
 import redis
@@ -42,14 +42,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -131,7 +131,7 @@ trigger = []
 for chan in channel:
     for mult in multiplier:
         trigger.append(TriggerThread(chan, mult, learning_rate))
-        print "x%d.%s" % (mult, chan)
+        print("x%d.%s" % (mult, chan))
 
 # start the thread for each of the triggers
 for thread in trigger:
@@ -141,10 +141,10 @@ try:
     while True:
         time.sleep(1)
         if debug > 0:
-            print "count =", count / len(multiplier)
+            print("count =", count / len(multiplier))
 
 except KeyboardInterrupt:
-    print "Closing threads"
+    print("Closing threads")
     for thread in trigger:
         thread.stop()
     r.publish('CLOCKMULTIPLIER_UNBLOCK', 1)

--- a/module/cogito/cogito.py
+++ b/module/cogito/cogito.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from copy import copy
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -46,14 +46,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -69,31 +69,31 @@ try:
     ftc_host = patch.getstring('input_fieldtrip', 'hostname')
     ftc_port = patch.getint('input_fieldtrip', 'port')
     if debug > 0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ft_input = FieldTrip.Client()
     ft_input.connect(ftc_host, ftc_port)
     if debug > 0:
-        print "Connected to input FieldTrip buffer"
+        print("Connected to input FieldTrip buffer")
 except:
-    print "Error: cannot connect to input FieldTrip buffer"
+    print("Error: cannot connect to input FieldTrip buffer")
     exit()
 
 try:
     ftc_host = patch.getstring('output_fieldtrip', 'hostname')
     ftc_port = patch.getint('output_fieldtrip', 'port')
     if debug > 0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ft_output = FieldTrip.Client()
     ft_output.connect(ftc_host, ftc_port)
     if debug > 0:
-        print "Connected to output FieldTrip buffer"
+        print("Connected to output FieldTrip buffer")
 except:
-    print "Error: cannot connect to output FieldTrip buffer"
+    print("Error: cannot connect to output FieldTrip buffer")
     exit()
 
 # get the input and output options
-input_number, input_channel = map(list, zip(*config.items('input_channel')))
-output_number, output_channel = map(list, zip(*config.items('output_channel')))
+input_number, input_channel = list(map(list, list(zip(*config.items('input_channel')))))
+output_number, output_channel = list(map(list, list(zip(*config.items('output_channel')))))
 
 # convert to integer and make the indices zero-offset
 input_number = [int(number)-1 for number in input_number]
@@ -103,18 +103,18 @@ hdr_input = None
 start = time.time()
 while hdr_input is None:
     if debug > 0:
-        print "Waiting for data to arrive..."
+        print("Waiting for data to arrive...")
     if (time.time()-start)>timeout:
-        print "Error: timeout while waiting for data"
+        print("Error: timeout while waiting for data")
         raise SystemExit
     hdr_input = ft_input.getHeader()
     time.sleep(0.2)
 
 if debug > 0:
-    print "Data arrived"
+    print("Data arrived")
 if debug > 1:
-    print hdr_input
-    print hdr_input.labels
+    print(hdr_input)
+    print(hdr_input.labels)
 
 # ensure that all input channels have a label
 nInputs = hdr_input.nChannels
@@ -128,7 +128,7 @@ for number, channel in zip(input_number, input_channel):
         hdr_input.labels[number] = channel
 
 # update the input channel specification
-input_number = range(nInputs)
+input_number = list(range(nInputs))
 input_channel = hdr_input.labels
 
 # ensure that all output channels have a label
@@ -138,16 +138,16 @@ for number, channel in zip(output_number, output_channel):
     tmp[number] = channel
 
 # update the output channel specification
-output_number = range(nOutputs)
+output_number = list(range(nOutputs))
 output_channel = tmp
 
 if debug > 0:
-    print '===== input channels ====='
+    print('===== input channels =====')
     for number, channel in zip(input_number, input_channel):
-        print number, '=', channel
-    print '===== output channels ====='
+        print(number, '=', channel)
+    print('===== output channels =====')
     for number, channel in zip(output_number, output_channel):
-        print number, '=', channel
+        print(number, '=', channel)
 
 sample_rate         = patch.getfloat('cogito', 'sample_rate')
 window              = patch.getfloat('cogito', 'window')
@@ -176,9 +176,9 @@ val = (val - val.min())/(val.max()-val.min())*definition
 positions = np.round(val).astype(int)
 
 if debug > 1:
-    print "nsample", hdr_input.nSamples
-    print "nchan", hdr_input.nChannels
-    print "window", window
+    print("nsample", hdr_input.nSamples)
+    print("nchan", hdr_input.nChannels)
+    print("window", window)
 
 # jump to the end of the stream
 if hdr_input.nSamples-1<window:
@@ -188,7 +188,7 @@ else:
     begsample = hdr_input.nSamples-window
     endsample = hdr_input.nSamples-1
 
-print "STARTING COGITO STREAM"
+print("STARTING COGITO STREAM")
 while True:
     start_time = time.time()
 
@@ -197,16 +197,16 @@ while True:
         time.sleep(patch.getfloat('general', 'delay'))
         hdr_input = ft_input.getHeader()
         if (hdr_input.nSamples-1)<(endsample-window):
-            print "Error: buffer reset detected"
+            print("Error: buffer reset detected")
             raise SystemExit
         if (time.time()-start_time)>timeout:
-            print "Error: timeout while waiting for data"
+            print("Error: timeout while waiting for data")
             raise SystemExit
 
     dat_input = ft_input.getData([begsample, endsample])
 
     if debug > 1:
-        print 'time waiting for data: ' + str((time.time() - start_time) * 1000)
+        print('time waiting for data: ' + str((time.time() - start_time) * 1000))
 
     # determine the start of the actual processing
     loop_time = time.time()
@@ -249,14 +249,14 @@ while True:
         tmp.append(convert)
 
         if debug > 1:
-            print 'time to process single channel: ' + str((time.time() - chan_time) * 1000)
+            print('time to process single channel: ' + str((time.time() - chan_time) * 1000))
 
     signal_time = time.time()
     signal = np.fft.irfft(np.concatenate(tmp), int(sample_rate))
     dat_output = np.atleast_2d(signal).T.astype(np.float32)
 
     if debug > 1:
-        print 'time to inverse FFT: ' + str((time.time() - signal_time) * 1000)
+        print('time to inverse FFT: ' + str((time.time() - signal_time) * 1000))
 
     write_time = time.time()
 
@@ -264,11 +264,11 @@ while True:
     ft_output.putData(dat_output)
 
     if debug > 1:
-        print 'time to write data to buffer: ' + str((time.time() - write_time) * 1000)
+        print('time to write data to buffer: ' + str((time.time() - write_time) * 1000))
 
     # increment the counters for the next loop
     begsample += window
     endsample += window
 
     if debug > 0:
-	    print "processed", window, "samples in", (time.time()-loop_time)*1000, "ms"
+	    print("processed", window, "samples in", (time.time()-loop_time)*1000, "ms")

--- a/module/eyeblink/eyeblink.py
+++ b/module/eyeblink/eyeblink.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from nilearn import signal
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -45,14 +45,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -69,31 +69,31 @@ try:
     ftc_host = patch.getstring('fieldtrip','hostname')
     ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ftc = FieldTrip.Client()
     ftc.connect(ftc_host, ftc_port)
     if debug>0:
-        print "Connected to FieldTrip buffer"
+        print("Connected to FieldTrip buffer")
 except:
-    print "Error: cannot connect to FieldTrip buffer"
+    print("Error: cannot connect to FieldTrip buffer")
     exit()
 
 hdr_input = None
 start = time.time()
 while hdr_input is None:
     if debug>0:
-        print "Waiting for data to arrive..."
+        print("Waiting for data to arrive...")
     if (time.time()-start)>timeout:
-        print "Error: timeout while waiting for data"
+        print("Error: timeout while waiting for data")
         raise SystemExit
     hdr_input = ftc.getHeader()
     time.sleep(0.2)
 
 if debug>0:
-    print "Data arrived"
+    print("Data arrived")
 if debug>1:
-    print hdr_input
-    print hdr_input.labels
+    print(hdr_input)
+    print(hdr_input.labels)
 
 class TriggerThread(threading.Thread):
     def __init__(self, r, config):
@@ -116,7 +116,7 @@ class TriggerThread(threading.Thread):
             for item in pubsub.listen():
                 if not self.running or not item['type'] == 'message':
                     break
-                print item['channel'], ":", item['data']
+                print(item['channel'], ":", item['data'])
                 lock.acquire()
                 self.last = self.time
                 lock.release()
@@ -151,7 +151,7 @@ try:
 
         hdr_input = ftc.getHeader()
         if (hdr_input.nSamples-1)<endsample:
-            print "Error: buffer reset detected"
+            print("Error: buffer reset detected")
             raise SystemExit
         endsample = hdr_input.nSamples - 1
         if endsample<window:
@@ -194,15 +194,15 @@ try:
         else:
             val = 0
 
-        print('spread ' + str(spread) +
+        print(('spread ' + str(spread) +
               '\t  max_spread : ' + str(maxval-minval) +
-              '\t  output ' + str(val))
+              '\t  output ' + str(val)))
 
         key = "%s.channel%d" % (patch.getstring('output','prefix'), channel+1)
         r.publish(key,val)
 
 except (KeyboardInterrupt, SystemExit):
-    print "Closing threads"
+    print("Closing threads")
     trigger.stop()
     r.publish('EYEBLINK_UNBLOCK', 1)
     trigger.join()

--- a/module/generateclock/generateclock.py
+++ b/module/generateclock/generateclock.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import math
 import mido
@@ -44,14 +44,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -72,7 +72,7 @@ offset_ppqn  = patch.getfloat('offset', 'ppqn')
 # this can be used to selectively show parameters that have changed
 def show_change(key, val):
     if (key not in show_change.previous) or (show_change.previous[key]!=val):
-        print key, "=", val
+        print(key, "=", val)
         show_change.previous[key] = val
         return True
     else:
@@ -108,7 +108,7 @@ class ClockThread(threading.Thread):
         slip = 0
         while self.running:
             if debug>1:
-                print 'clock beat'
+                print('clock beat')
             start  = time.time()
             delay  = 60/self.rate   # the rate is in bpm
             delay -= slip           # correct for the slip from the previous iteration
@@ -138,7 +138,7 @@ class MidiThread(threading.Thread):
         while self.running:
             if self.enabled and midiport:
                 if debug>1:
-                    print 'midi beat'
+                    print('midi beat')
                 for tick in clock:
                     tick.wait()
                     midiport.send(msg)
@@ -161,14 +161,14 @@ class RedisThread(threading.Thread):
                 self.ppqn = ppqn
                 self.clock = np.mod(np.arange(0, 24, 24/self.ppqn) + self.shift, 24)
                 if debug>0:
-                    print "redis select =", self.clock
+                    print("redis select =", self.clock)
     def setShift(self, shift):
         if shift != self.shift:
             with lock:
                 self.shift = shift
                 self.clock = np.mod(np.arange(0, 24, 24/self.ppqn) + self.shift, 24)
                 if debug>0:
-                    print "redis select =", self.clock
+                    print("redis select =", self.clock)
     def setEnabled(self, enabled):
         self.enabled = enabled
     def stop(self):
@@ -178,7 +178,7 @@ class RedisThread(threading.Thread):
         while self.running:
             if self.enabled:
                 if debug>1:
-                    print 'redis beat'
+                    print('redis beat')
                 for tick in [clock[indx] for indx in self.clock]:
                     tick.wait()
                     patch.setvalue(self.key, 1.)
@@ -211,7 +211,7 @@ try: # FIXME do we need this or can we catch errors before?
         now = time.time()
 
         if debug>3:
-            print 'loop'
+            print('loop')
 
         redis_play  = patch.getint('redis', 'play')
         midi_play   = patch.getint('midi', 'play')
@@ -287,11 +287,11 @@ try: # FIXME do we need this or can we catch errors before?
         naptime = patch.getfloat('general', 'delay') - elapsed
         if naptime>0:
             if debug>3:
-                print "naptime =", naptime
+                print("naptime =", naptime)
             time.sleep(naptime)
 
 except (KeyboardInterrupt, RuntimeError) as e:
-    print "Closing threads"
+    print("Closing threads")
     midithread.stop()
     midithread.join()
     redisthread.stop()

--- a/module/generatecontrol/generatecontrol.py
+++ b/module/generatecontrol/generatecontrol.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -44,14 +44,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -75,7 +75,7 @@ offset_dutycycle  = patch.getfloat('offset', 'dutycycle', default=0)
 stepsize          = patch.getfloat('generate', 'stepsize') # in seconds
 
 if debug > 1:
-    print "update", update
+    print("update", update)
 
 prev_frequency = -1
 prev_amplitude = -1
@@ -87,19 +87,19 @@ prev_dutycycle = -1
 sample = 0
 phase = 0
 
-print "STARTING STREAM"
+print("STARTING STREAM")
 while True:
 
     if patch.getint('signal', 'rewind', default=0):
         if debug>0:
-            print "Rewind pressed, jumping back to start of signal"
+            print("Rewind pressed, jumping back to start of signal")
         # the sample number and phase should be 0 upon the start of the signal
         sample = 0
         phase = 0
 
     if not patch.getint('signal', 'play', default=1):
         if debug>0:
-            print "Stopped"
+            print("Stopped")
         time.sleep(0.1)
         # the sample number and phase should be 0 upon the start of the signal
         sample = 0
@@ -108,7 +108,7 @@ while True:
 
     if patch.getint('signal', 'pause', default=0):
         if debug>0:
-            print "Paused"
+            print("Paused")
         time.sleep(0.1)
         continue
 
@@ -129,19 +129,19 @@ while True:
     dutycycle = EEGsynth.rescale(dutycycle, slope=scale_dutycycle, offset=offset_dutycycle)
 
     if frequency!=prev_frequency or debug>2:
-        print "frequency =", frequency
+        print("frequency =", frequency)
         prev_frequency = frequency
     if amplitude!=prev_amplitude or debug>2:
-        print "amplitude =", amplitude
+        print("amplitude =", amplitude)
         prev_amplitude = amplitude
     if offset!=prev_offset or debug>2:
-        print "offset    =", offset
+        print("offset    =", offset)
         prev_offset = offset
     if noise!=prev_noise or debug>2:
-        print "noise     =", noise
+        print("noise     =", noise)
         prev_noise = noise
     if dutycycle!=prev_dutycycle or debug>2:
-        print "dutycycle =", dutycycle
+        print("dutycycle =", dutycycle)
         prev_dutycycle = dutycycle
 
     # compute the phase of this sample
@@ -174,4 +174,4 @@ while True:
 
     sample += 1
     if debug>0:
-        print "generated sample", sample, "in", (time.time()-start)*1000, "ms"
+        print("generated sample", sample, "in", (time.time()-start)*1000, "ms")

--- a/module/generatesignal/generatesignal.py
+++ b/module/generatesignal/generatesignal.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -45,14 +45,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -66,13 +66,13 @@ try:
     ftc_host = patch.getstring('fieldtrip','hostname')
     ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ft_output = FieldTrip.Client()
     ft_output.connect(ftc_host, ftc_port)
     if debug>0:
-        print "Connected to output FieldTrip buffer"
+        print("Connected to output FieldTrip buffer")
 except:
-    print "Error: cannot connect to output FieldTrip buffer"
+    print("Error: cannot connect to output FieldTrip buffer")
     exit()
 
 datatype  = FieldTrip.DATATYPE_FLOAT32
@@ -83,9 +83,9 @@ blocksize = int(round(patch.getfloat('generate', 'window') * fsample))
 ft_output.putHeader(nchannels, fsample, datatype)
 
 if debug > 1:
-    print "nchannels", nchannels
-    print "fsample", fsample
-    print "blocksize", blocksize
+    print("nchannels", nchannels)
+    print("fsample", fsample)
+    print("blocksize", blocksize)
 
 # the scale and offset are used to map Redis values to signal parameters
 scale_frequency   = patch.getfloat('scale', 'frequency', default=1)
@@ -114,19 +114,19 @@ endsample = blocksize-1
 timevec  = np.arange(1, blocksize+1) / fsample
 phasevec = np.zeros(1)
 
-print "STARTING STREAM"
+print("STARTING STREAM")
 while True:
 
     if patch.getint('signal', 'rewind', default=0):
         if debug>0:
-            print "Rewind pressed, jumping back to start of signal"
+            print("Rewind pressed, jumping back to start of signal")
         # the sample number and phase should be 0 upon the start of the signal
         sample = 0
         phase = 0
 
     if not patch.getint('signal', 'play', default=1):
         if debug>0:
-            print "Stopped"
+            print("Stopped")
         time.sleep(0.1);
         # the sample number and phase should be 0 upon the start of the signal
         sample = 0
@@ -135,7 +135,7 @@ while True:
 
     if patch.getint('signal', 'pause', default=0):
         if debug>0:
-            print "Paused"
+            print("Paused")
         time.sleep(0.1);
         continue
 
@@ -143,7 +143,7 @@ while True:
     start = time.time();
 
     if debug>1:
-        print "Generating block", block, 'from', begsample, 'to', endsample
+        print("Generating block", block, 'from', begsample, 'to', endsample)
 
     frequency = patch.getfloat('signal', 'frequency', default=10)
     amplitude = patch.getfloat('signal', 'amplitude', default=0.8)
@@ -158,19 +158,19 @@ while True:
     dutycycle = EEGsynth.rescale(dutycycle, slope=scale_dutycycle, offset=offset_dutycycle)
 
     if frequency!=prev_frequency or debug>2:
-        print "frequency =", frequency
+        print("frequency =", frequency)
         prev_frequency = frequency
     if amplitude!=prev_amplitude or debug>2:
-        print "amplitude =", amplitude
+        print("amplitude =", amplitude)
         prev_amplitude = amplitude
     if offset!=prev_offset or debug>2:
-        print "offset    =", offset
+        print("offset    =", offset)
         prev_offset = offset
     if noise!=prev_noise or debug>2:
-        print "noise     =", noise
+        print("noise     =", noise)
         prev_noise = noise
     if dutycycle!=prev_dutycycle or debug>2:
-        print "dutycycle =", dutycycle
+        print("dutycycle =", dutycycle)
         prev_dutycycle = dutycycle
 
     # compute the phase of each sample in this block
@@ -205,4 +205,4 @@ while True:
         time.sleep(naptime)
 
     if debug>0:
-        print "generated", blocksize, "samples in", (time.time()-start)*1000, "ms"
+        print("generated", blocksize, "samples in", (time.time()-start)*1000, "ms")

--- a/module/geomixer/geomixer.py
+++ b/module/geomixer/geomixer.py
@@ -19,7 +19,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser  # this is version 2.x specific,on version 3.x it is called "configparser" and has a different API
+from __future__ import print_function
+
+import configparser
 import argparse
 import math
 import numpy as np
@@ -46,14 +48,14 @@ parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder,
                                                             os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -62,7 +64,7 @@ patch = EEGsynth.patch(config, r)
 # this can be used to selectively show parameters that have changed
 def show_change(key, val):
     if (key not in show_change.previous) or (show_change.previous[key]!=val):
-        print key, "=", val
+        print(key, "=", val)
         show_change.previous[key] = val
         return True
     else:
@@ -128,7 +130,7 @@ while True:
         upper_treshold = 1. + switch_precision
 
     if debug > 1:
-        print '------------------------------------------------------------------'
+        print('------------------------------------------------------------------')
 
     # is there a reason to change?
     if even(edge):
@@ -154,7 +156,7 @@ while True:
     else:
         dwelltime += delay
         if debug > 1:
-            print 'dwelling for', dwelltime
+            print('dwelling for', dwelltime)
     previous = change
 
     # is the dwelltime long enough?
@@ -169,7 +171,7 @@ while True:
         key = '%s.%s.edge' % (prefix, patch.getstring('input', 'channel'))
         patch.setvalue(key, edge)
         if debug > 1:
-            print 'switch to edge', edge
+            print('switch to edge', edge)
 
     channel_val = [0. for i in range(number)]
     for this in range(number):
@@ -186,10 +188,10 @@ while True:
 
     if debug > 0:
         # print them all on a single line, this is Python 2 specific
-        print('edge=%2d' % edge),
+        print(('edge=%2d' % edge), end=' ')
         for key, val in zip(channel_name, channel_val):
-            print(' %s = %0.2f' % (key, val)),
-        print ""  # force a newline
+            print((' %s = %0.2f' % (key, val)), end=' ')
+        print('')  # force a newline
 
     # this is a short-term approach, estimating the sleep for every block
     # this code is shared between generatesignal, playback and playbackctrl

--- a/module/heartrate/heartrate.py
+++ b/module/heartrate/heartrate.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser
+import configparser
 import argparse
 import numpy as np
 import os
@@ -45,14 +45,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -69,31 +69,31 @@ try:
     ftc_host = patch.getstring('fieldtrip', 'hostname')
     ftc_port = patch.getint('fieldtrip', 'port')
     if debug > 0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ft_input = FieldTrip.Client()
     ft_input.connect(ftc_host, ftc_port)
     if debug > 0:
-        print "Connected to input FieldTrip buffer"
+        print("Connected to input FieldTrip buffer")
 except:
-    print "Error: cannot connect to input FieldTrip buffer"
+    print("Error: cannot connect to input FieldTrip buffer")
     exit()
 
 hdr_input = None
 start = time.time()
 while hdr_input is None:
     if debug>0:
-        print "Waiting for data to arrive..."
+        print("Waiting for data to arrive...")
     if (time.time()-start)>timeout:
-        print "Error: timeout while waiting for data"
+        print("Error: timeout while waiting for data")
         raise SystemExit
     hdr_input = ft_input.getHeader()
     time.sleep(0.2)
 
 if debug>0:
-    print "Data arrived"
+    print("Data arrived")
 if debug>1:
-    print hdr_input
-    print hdr_input.labels
+    print(hdr_input)
+    print(hdr_input.labels)
 
 channel   = patch.getint('input','channel')-1                                 # one-offset in the ini file, zero-offset in the code
 window    = round(patch.getfloat('processing','window') * hdr_input.fSample)  # in samples
@@ -116,12 +116,12 @@ while True:
 
     hdr_input = ft_input.getHeader()
     if (hdr_input.nSamples-1)<endsample:
-        print "Error: buffer reset detected"
+        print("Error: buffer reset detected")
         raise SystemExit
     if hdr_input.nSamples < window:
         # there are not yet enough samples in the buffer
         if debug>0:
-            print "Waiting for data..."
+            print("Waiting for data...")
         continue
 
     # process the last window

--- a/module/historycontrol/historycontrol.py
+++ b/module/historycontrol/historycontrol.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from numpy import log, log2, log10, exp, power, sqrt, mean, median, var, std
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -45,14 +45,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -93,16 +93,16 @@ while True:
 
     if enable and prev_enable:
         if debug > 0:
-            print "Updating"
+            print("Updating")
     elif enable and not prev_enable:
         if debug > 0:
-            print "Enabling the updating"
+            print("Enabling the updating")
     elif not enable and not prev_enable:
         if debug > 0:
-            print "Not updating"
+            print("Not updating")
     elif not enable and prev_enable:
         if debug > 0:
-            print "Disabling the updating"
+            print("Disabling the updating")
 
     if not enable:
         time.sleep(0.1)
@@ -144,13 +144,13 @@ while True:
         historic['min_att'] = np.nanmin(history_att, axis=1)
         historic['max_att'] = np.nanmax(history_att, axis=1)
 
-        for operation in historic.keys():
+        for operation in list(historic.keys()):
             for channel in range(numchannel):
                 key = inputlist[channel] + "." + operation
                 val = historic[operation][channel]
                 patch.setvalue(key, val)
                 if debug>1:
-                    print key + ':' + str(val)
+                    print(key + ':' + str(val))
 
         elapsed = time.time() - start
         naptime = stepsize - elapsed

--- a/module/inputmidi/inputmidi.py
+++ b/module/inputmidi/inputmidi.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import mido
 import os
@@ -43,14 +43,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -73,9 +73,9 @@ offset = patch.getfloat('output', 'offset', default=0)
 try:
     inputport  = mido.open_input(patch.getstring('midi', 'device'))
     if debug>0:
-        print "Connected to MIDI input"
+        print("Connected to MIDI input")
 except:
-    print "Error: cannot connect to MIDI input"
+    print("Error: cannot connect to MIDI input")
     exit()
 
 while True:
@@ -84,7 +84,7 @@ while True:
     for msg in inputport.iter_pending():
 
         if debug>1:
-            print msg
+            print(msg)
 
         if hasattr(msg, "control"):
             # prefix.control000=value

--- a/module/inputosc/inputosc.py
+++ b/module/inputosc/inputosc.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser  # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import OSC          # see https://trac.v2.nl/wiki/pyOSC
 import argparse
 import os
@@ -45,14 +45,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -65,10 +65,10 @@ debug = patch.getint('general', 'debug')
 try:
     s = OSC.OSCServer((patch.getstring('osc', 'address'), patch.getint('osc', 'port')))
     if debug > 0:
-        print "Started OSC server"
+        print("Started OSC server")
 except:
-    print "Unexpected error:", sys.exc_info()[0]
-    print "Error: cannot start OSC server"
+    print("Unexpected error:", sys.exc_info()[0])
+    print("Error: cannot start OSC server")
     exit()
 
 # this is a list of OSC messages that are to be processed as button presses, i.e. using a pubsub message in redis
@@ -92,11 +92,11 @@ def forward_handler(addr, tags, data, source):
     global offset
 
     if debug > 1:
-        print "---"
-        print "source %s" % OSC.getUrlStr(source)
-        print "addr   %s" % addr
-        print "tags   %s" % tags
-        print "data   %s" % data
+        print("---")
+        print("source %s" % OSC.getUrlStr(source))
+        print("addr   %s" % addr)
+        print("tags   %s" % tags)
+        print("data   %s" % data)
 
     if addr[0] != '/':
         # ensure it starts with a slash
@@ -122,12 +122,12 @@ s.addDefaultHandlers()
 # s.addMsgHandler("/1/faderA", test_handler)
 
 # just checking which handlers we have added
-print "Registered Callback-functions are :"
+print("Registered Callback-functions are :")
 for addr in s.getOSCAddressSpace():
-    print addr
+    print(addr)
 
 # start the server thread
-print "\nStarting module. Use ctrl-C to quit."
+print("\nStarting module. Use ctrl-C to quit.")
 st = threading.Thread(target=s.serve_forever)
 st.start()
 
@@ -142,8 +142,8 @@ try:
         prefix = patch.getstring('output', 'prefix')
 
 except KeyboardInterrupt:
-    print "\nClosing module."
+    print("\nClosing module.")
     s.close()
-    print "Waiting for Server-thread to finish."
+    print("Waiting for Server-thread to finish.")
     st.join()
-    print "Done."
+    print("Done.")

--- a/module/keyboard/keyboard.py
+++ b/module/keyboard/keyboard.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called 'configparser' and has a different API
+import configparser
 import argparse
 import mido
 import os
@@ -49,14 +49,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print 'Error: cannot connect to redis server'
+    print('Error: cannot connect to redis server')
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -78,17 +78,17 @@ mididevice = patch.getstring('midi', 'device')
 try:
     inputport  = mido.open_input(mididevice)
     if debug>0:
-        print "Connected to MIDI input"
+        print("Connected to MIDI input")
 except:
-    print "Error: cannot connect to MIDI input"
+    print("Error: cannot connect to MIDI input")
     exit()
 
 try:
     outputport  = mido.open_output(mididevice)
     if debug>0:
-        print "Connected to MIDI output"
+        print("Connected to MIDI output")
 except:
-    print "Error: cannot connect to MIDI output"
+    print("Error: cannot connect to MIDI output")
     exit()
 
 try:
@@ -120,7 +120,7 @@ lock = threading.Lock()
 # this is used to send direct and delayed messages
 def SendMessage(msg):
     lock.acquire()
-    print msg
+    print(msg)
     outputport.send(msg)
     lock.release()
 
@@ -176,11 +176,11 @@ class TriggerThread(threading.Thread):
                         duration = self.duration
 
                     if debug>1:
-                        print '----------------------------------------------'
-                        print "onset   ", self.onset,       "=", val
-                        print "velocity", self.velocity,    "=", velocity
-                        print "pitch   ", self.pitch,       "=", pitch
-                        print "duration", self.duration,    "=", duration
+                        print('----------------------------------------------')
+                        print("onset   ", self.onset,       "=", val)
+                        print("velocity", self.velocity,    "=", velocity)
+                        print("pitch   ", self.pitch,       "=", pitch)
+                        print("duration", self.duration,    "=", duration)
 
                     if midichannel is None:
                         msg = mido.Message('note_on', note=pitch, velocity=velocity)
@@ -208,7 +208,7 @@ for name, code in zip(note_name, note_code):
         duration = None
         trigger.append(TriggerThread(onset, velocity, pitch, duration))
         if debug>1:
-            print name, 'OK'
+            print(name, 'OK')
 
 try:
     # the keyboard notes can also be controlled using a single trigger
@@ -218,7 +218,7 @@ try:
     duration = patch.getstring('input', 'duration')
     trigger.append(TriggerThread(onset, velocity, pitch, duration))
     if debug>1:
-        print 'onset, velocity, pitch and duration OK'
+        print('onset, velocity, pitch and duration OK')
 except:
     pass
 
@@ -239,7 +239,7 @@ try:
                     pass
 
             if debug>0 and msg.type!='clock':
-                print msg
+                print(msg)
 
             if hasattr(msg,'note'):
                 print(msg)
@@ -265,7 +265,7 @@ try:
                 pass
 
 except KeyboardInterrupt:
-    print 'Closing threads'
+    print('Closing threads')
     for thread in trigger:
         thread.stop()
     r.publish('KEYBOARD_UNBLOCK', 1)

--- a/module/launchcontrol/launchcontrol.py
+++ b/module/launchcontrol/launchcontrol.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import mido
 import os
@@ -43,14 +43,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -80,23 +80,23 @@ try:
 except:
     mididevice_output = patch.getstring('midi', 'device') # fallback
 
-print mididevice_input
-print mididevice_output
+print(mididevice_input)
+print(mididevice_output)
 
 try:
     inputport = mido.open_input(mididevice_input)
     if debug > 0:
-        print "Connected to MIDI input"
+        print("Connected to MIDI input")
 except:
-    print "Error: cannot connect to MIDI input"
+    print("Error: cannot connect to MIDI input")
     exit()
 
 try:
     outputport = mido.open_output(mididevice_output)
     if debug > 0:
-        print "Connected to MIDI output"
+        print("Connected to MIDI output")
 except:
-    print "Error: cannot connect to MIDI output"
+    print("Error: cannot connect to MIDI output")
     exit()
 
 try:
@@ -106,7 +106,7 @@ except:
     # this happens if it is not specified in the ini file
     # it will be determined on the basis of the first incoming message
     midichannel = None
-print "midichannel = ", midichannel
+print("midichannel = ", midichannel)
 
 push    = patch.getint('button', 'push',    multiple=True)      # push-release button
 toggle1 = patch.getint('button', 'toggle1', multiple=True)      # on-off button
@@ -189,7 +189,7 @@ while True:
                 pass
 
         if debug>1 and msg.type!='clock':
-            print msg
+            print(msg)
 
         if hasattr(msg, "control"):
             # e.g. prefix.control000=value
@@ -212,48 +212,48 @@ while True:
             if msg.note in toggle1:
                 status = state1change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state1color.keys():
+                if status in list(state1color.keys()):
                     ledcolor(msg.note, state1color[status])
-                if status in state1value.keys():
+                if status in list(state1value.keys()):
                     val = state1value[status]
             elif msg.note in toggle2:
                 status = state2change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state2color.keys():
+                if status in list(state2color.keys()):
                     ledcolor(msg.note, state2color[status])
-                if status in state2value.keys():
+                if status in list(state2value.keys()):
                     val = state2value[status]
             elif msg.note in toggle3:
                 status = state3change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state3color.keys():
+                if status in list(state3color.keys()):
                     ledcolor(msg.note, state3color[status])
-                if status in state3value.keys():
+                if status in list(state3value.keys()):
                     val = state3value[status]
             elif msg.note in toggle4:
                 status = state4change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state4color.keys():
+                if status in list(state4color.keys()):
                     ledcolor(msg.note, state4color[status])
-                if status in state4value.keys():
+                if status in list(state4value.keys()):
                     val = state4value[status]
             elif msg.note in slap:
                 status = state5change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state5color.keys():
+                if status in list(state5color.keys()):
                     ledcolor(msg.note, state5color[status])
-                if status in state5value.keys():
+                if status in list(state5value.keys()):
                     val = state5value[status]
             else:
                 status = state0change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state0color.keys():
+                if status in list(state0color.keys()):
                     ledcolor(msg.note, state0color[status])
-                if status in state0value.keys():
+                if status in list(state0value.keys()):
                     val = state0value[status]
 
             if debug > 1:
-                print status, val
+                print(status, val)
 
             if not val is None:
                 # prefix.noteXXX=value

--- a/module/launchpad/launchpad.py
+++ b/module/launchpad/launchpad.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import mido
 import os
@@ -43,14 +43,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -73,17 +73,17 @@ mididevice = patch.getstring('midi', 'device')
 try:
     inputport  = mido.open_input(mididevice)
     if debug>0:
-        print "Connected to MIDI input"
+        print("Connected to MIDI input")
 except:
-    print "Error: cannot connect to MIDI input"
+    print("Error: cannot connect to MIDI input")
     exit()
 
 try:
     outputport  = mido.open_output(mididevice)
     if debug>0:
-        print "Connected to MIDI output"
+        print("Connected to MIDI output")
 except:
-    print "Error: cannot connect to MIDI output"
+    print("Error: cannot connect to MIDI output")
     exit()
 
 try:
@@ -93,7 +93,7 @@ except:
     # this happens if it is not specified in the ini file
     # it will be determined on the basis of the first incoming message
     midichannel = None
-print "midichannel = ", midichannel
+print("midichannel = ", midichannel)
 
 push     = patch.getint('button', 'push',    multiple=True)    # push-release button
 toggle1  = patch.getint('button', 'toggle1', multiple=True)    # on-off button
@@ -175,7 +175,7 @@ while True:
                 pass
 
         if debug>1 and msg.type!='clock':
-            print msg
+            print(msg)
 
         if hasattr(msg, "control"):
             # e.g. prefix.control000=value
@@ -198,48 +198,48 @@ while True:
             if msg.note in toggle1:
                 status = state1change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state1color.keys():
+                if status in list(state1color.keys()):
                     ledcolor(msg.note, state1color[status])
-                if status in state1value.keys():
+                if status in list(state1value.keys()):
                     val = state1value[status]
             elif msg.note in toggle2:
                 status = state2change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state2color.keys():
+                if status in list(state2color.keys()):
                     ledcolor(msg.note, state2color[status])
-                if status in state2value.keys():
+                if status in list(state2value.keys()):
                     val = state2value[status]
             elif msg.note in toggle3:
                 status = state3change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state3color.keys():
+                if status in list(state3color.keys()):
                     ledcolor(msg.note, state3color[status])
-                if status in state3value.keys():
+                if status in list(state3value.keys()):
                     val = state3value[status]
             elif msg.note in toggle4:
                 status = state4change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state4color.keys():
+                if status in list(state4color.keys()):
                     ledcolor(msg.note, state4color[status])
-                if status in state4value.keys():
+                if status in list(state4value.keys()):
                     val = state4value[status]
             elif msg.note in slap:
                 status = state5change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state5color.keys():
+                if status in list(state5color.keys()):
                     ledcolor(msg.note, state5color[status])
-                if status in state5value.keys():
+                if status in list(state5value.keys()):
                     val = state5value[status]
             else:
                 status = state0change[status]
                 status_list[note_list.index(msg.note)] = status # remember the state
-                if status in state0color.keys():
+                if status in list(state0color.keys()):
                     ledcolor(msg.note, state0color[status])
-                if status in state0value.keys():
+                if status in list(state0value.keys()):
                     val = state0value[status]
 
             if debug > 1:
-                print status, val
+                print(status, val)
 
             if not val is None:
                 # prefix.noteXXX=value

--- a/module/outputartnet/outputartnet.py
+++ b/module/outputartnet/outputartnet.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import os
 import redis
@@ -44,14 +44,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -85,7 +85,7 @@ try:
             if chanval==None:
                 # the value is not present in Redis, skip it
                 if debug>2:
-                    print chanstr, 'not available'
+                    print(chanstr, 'not available')
                 continue
 
             # the scale and offset options are channel specific
@@ -101,7 +101,7 @@ try:
                 # update the DMX value for this channel
                 dmxdata[chanindx-1] = chanval
                 if debug>1:
-                    print "DMX channel%03d" % chanindx, '=', chanval
+                    print("DMX channel%03d" % chanindx, '=', chanval)
                 artnet.broadcastDMX(dmxdata,address)
             elif (time.time()-prevtime)>1:
                 # send a maintenance packet now and then
@@ -111,7 +111,7 @@ try:
 except KeyboardInterrupt:
     # blank out
     if debug>0:
-        print "closing..."
+        print("closing...")
     dmxdata = [0] * 512
     artnet.broadcastDMX(dmxdata,address)
     time.sleep(0.1) # this seems to take some time

--- a/module/outputcvgate/outputcvgate.py
+++ b/module/outputcvgate/outputcvgate.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser  # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import os
 import redis
@@ -44,14 +44,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -68,9 +68,9 @@ duration_offset = patch.getfloat('duration', 'offset', default=0)
 try:
     s = serial.Serial(patch.getstring('serial', 'device'), patch.getint('serial', 'baudrate'), timeout=3.0)
     if debug > 0:
-        print "Connected to serial port"
+        print("Connected to serial port")
 except:
-    print "Error: cannot connect to serial port"
+    print("Error: cannot connect to serial port")
     exit()
 
 # this is to prevent two triggers from being activated at the same time
@@ -79,7 +79,7 @@ lock = threading.Lock()
 # this can be used to selectively show parameters that have changed
 def show_change(key, val):
     if (key not in show_change.previous) or (show_change.previous[key]!=val):
-        print key, "=", val
+        print(key, "=", val)
         show_change.previous[key] = val
         return True
     else:
@@ -89,7 +89,7 @@ show_change.previous = {}
 
 def SetGate(gate, val):
     if debug > 1:
-        print "gate%d" % (gate), "=", val
+        print("gate%d" % (gate), "=", val)
     lock.acquire()
     s.write('*g%dv%d#' % (gate, val))
     lock.release()
@@ -141,7 +141,7 @@ for chanindx in range(1, 5):
         except:
             trigger.append(TriggerThread(channel, chanindx, None))
         if debug > 0:
-            print "configured", channel, chanindx
+            print("configured", channel, chanindx)
     except:
         pass
 
@@ -162,7 +162,7 @@ try:
             if chanval == None:
                 # the value is not present in Redis, skip it
                 if debug > 2:
-                    print chanstr, 'not available'
+                    print(chanstr, 'not available')
                 continue
 
             # the scale and offset options are channel specific
@@ -188,7 +188,7 @@ try:
             if chanval == None:
                 # the value is not present in Redis, skip it
                 if debug > 2:
-                    print chanstr, 'not available'
+                    print(chanstr, 'not available')
                 continue
 
             # the scale and offset options are channel specific
@@ -207,7 +207,7 @@ try:
             lock.release()
 
 except KeyboardInterrupt:
-    print "Closing threads"
+    print("Closing threads")
     for thread in trigger:
         thread.stop()
     r.publish('OUTPUTCVGATE_UNBLOCK', 1)

--- a/module/outputdmx512/outputdmx512.py
+++ b/module/outputdmx512/outputdmx512.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import os
 import redis
@@ -43,14 +43,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -71,9 +71,9 @@ try:
     # rtscts=0
     s.open()
     if debug>0:
-        print "Connected to serial port"
+        print("Connected to serial port")
 except:
-    print "Error: cannot connect to serial port"
+    print("Error: cannot connect to serial port")
     exit()
 
 # give the device some time to initialize
@@ -81,13 +81,13 @@ time.sleep(2)
 
 # determine the size of the universe
 dmxsize = 16
-chanlist,chanvals = map(list, zip(*config.items('input')))
+chanlist,chanvals = list(map(list, list(zip(*config.items('input')))))
 for chanindx in range(1, 512):
     chanstr = "channel%03d" % chanindx
     if chanstr in chanlist:
         dmxsize = chanindx
 if debug>0:
-    print "universe size = %d" % dmxsize
+    print("universe size = %d" % dmxsize)
 
 # This is from https://www.enttec.com/docs/dmx_usb_pro_api_spec.pdf
 #
@@ -150,7 +150,7 @@ try:
             if chanval==None:
                 # the value is not present in Redis, skip it
                 if debug>2:
-                    print chanstr, 'not available'
+                    print(chanstr, 'not available')
                 continue
 
             # the scale and offset options are channel specific
@@ -164,7 +164,7 @@ try:
 
             if dmxdata[chanindx]!=chr(chanval):
                 if debug>0:
-                    print "DMX channel%03d" % chanindx, '=', chanval
+                    print("DMX channel%03d" % chanindx, '=', chanval)
                 # update the DMX value for this channel
                 dmxdata = senddmx(dmxdata,chanindx,chanval)
             elif (time.time()-prevtime)>1:
@@ -174,5 +174,5 @@ try:
 
 except KeyboardInterrupt:
     if debug>0:
-        print "closing..."
+        print("closing...")
     sys.exit()

--- a/module/outputgpio/outputgpio.py
+++ b/module/outputgpio/outputgpio.py
@@ -19,8 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
-import ConfigParser
+import configparser
 import argparse
 import os
 import redis
@@ -46,14 +45,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -97,7 +96,7 @@ lock = threading.Lock()
 def SetGPIO(gpio, val=1):
     lock.acquire()
     if debug > 1:
-        print gpio, pin[gpio], val
+        print(gpio, pin[gpio], val)
     wiringpi.digitalWrite(pin[gpio], val)
     lock.release()
 
@@ -145,7 +144,7 @@ wiringpi.wiringPiSetup()
 # set up PWM for the control channels
 previous_val = {}
 for gpio, channel in config.items('control'):
-    print "control", channel, gpio
+    print("control", channel, gpio)
     wiringpi.softPwmCreate(pin[gpio], 0, 100)
     # control values are only relevant when different from the previous value
     previous_val[gpio] = None
@@ -159,7 +158,7 @@ for gpio, channel in config.items('trigger'):
     except:
         duration = None
     trigger.append(TriggerThread(channel, gpio, duration))
-    print "trigger", channel, gpio
+    print("trigger", channel, gpio)
 
 # start the thread for each of the triggers
 for thread in trigger:
@@ -185,7 +184,7 @@ try:
             lock.release()
 
 except KeyboardInterrupt:
-    print "Closing threads"
+    print("Closing threads")
     for thread in trigger:
         thread.stop()
     r.publish('OUTPUTGPIO_UNBLOCK', 1)

--- a/module/outputmidi/outputmidi.py
+++ b/module/outputmidi/outputmidi.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import mido
 import os
@@ -44,14 +44,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -75,7 +75,7 @@ lock = threading.Lock()
 
 def sendMidi(name, code, val):
     if debug>0:
-        print name, code, val
+        print(name, code, val)
     # the different MIDI messages have slightly different parameters
     if name.startswith('note'):
         if midichannel is None:
@@ -135,7 +135,7 @@ class TriggerThread(threading.Thread):
                     break
                 if item['channel']==self.redischannel:
                     if debug>1:
-                        print item['channel'], '=', item['data']
+                        print(item['channel'], '=', item['data'])
                     # map the Redis values to MIDI values
                     val = item['data']
                     val = EEGsynth.rescale(val, slope=input_scale, offset=input_offset)
@@ -164,7 +164,7 @@ for name, code in zip(trigger_name, trigger_code):
         this = TriggerThread(patch.getstring('trigger', name), name, code)
         trigger.append(this)
         if debug>1:
-            print name, 'trigger configured'
+            print(name, 'trigger configured')
 
 # start the thread for each of the triggers
 for thread in trigger:
@@ -209,7 +209,7 @@ try:
 
 
 except KeyboardInterrupt:
-    print "Closing threads"
+    print("Closing threads")
     for thread in trigger:
         thread.stop()
     r.publish('OUTPUTMIDI_UNBLOCK', 1)

--- a/module/outputosc/outputosc.py
+++ b/module/outputosc/outputosc.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import OSC          # see https://trac.v2.nl/wiki/pyOSC
 import argparse
 import os
@@ -43,14 +43,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -63,9 +63,9 @@ try:
     s = OSC.OSCClient()
     s.connect((patch.getstring('osc','hostname'), patch.getint('osc','port')))
     if debug>0:
-        print "Connected to OSC server"
+        print("Connected to OSC server")
 except:
-    print "Error: cannot connect to OSC server"
+    print("Error: cannot connect to OSC server")
     exit()
 
 # keys should be present in both the input and output section of the *.ini file
@@ -101,7 +101,7 @@ while True:
         val = EEGsynth.rescale(val, slope=scale, offset=offset)
 
         if debug>1:
-            print 'OSC message', key3, '=', val
+            print('OSC message', key3, '=', val)
 
         msg = OSC.OSCMessage(key3)
         msg.append(val)

--- a/module/playbacksignal/playbacksignal.py
+++ b/module/playbacksignal/playbacksignal.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -47,14 +47,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -68,13 +68,13 @@ try:
     ftc_host = patch.getstring('fieldtrip','hostname')
     ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ftc = FieldTrip.Client()
     ftc.connect(ftc_host, ftc_port)
     if debug>0:
-        print "Connected to FieldTrip buffer"
+        print("Connected to FieldTrip buffer")
 except:
-    print "Error: cannot connect to FieldTrip buffer"
+    print("Error: cannot connect to FieldTrip buffer")
     exit()
 
 try:
@@ -85,7 +85,7 @@ except:
     fileformat = ext[1:]
 
 if debug>0:
-    print "Reading data from", patch.getstring('playback', 'file')
+    print("Reading data from", patch.getstring('playback', 'file'))
 
 H = FieldTrip.Header()
 
@@ -114,7 +114,7 @@ if fileformat=='edf':
     # read all the data from the file
     A = np.ndarray(shape=(H.nSamples, H.nChannels), dtype=np.float32)
     for chanindx in range(H.nChannels):
-        print "reading channel", chanindx
+        print("reading channel", chanindx)
         A[:,chanindx] = f.readSignal(chanindx)
     f.close()
 
@@ -158,10 +158,10 @@ else:
     raise NotImplementedError('unsupported file format')
 
 if debug>1:
-    print "nChannels", H.nChannels
-    print "nSamples", H.nSamples
-    print "fSample", H.fSample
-    print "labels", labels
+    print("nChannels", H.nChannels)
+    print("nSamples", H.nSamples)
+    print("fSample", H.fSample)
+    print("labels", labels)
 
 ftc.putHeader(H.nChannels, H.fSample, H.dataType, labels=labels)
 
@@ -170,32 +170,32 @@ begsample = 0
 endsample = blocksize-1
 block     = 0
 
-print "STARTING STREAM"
+print("STARTING STREAM")
 while True:
 
     if endsample>H.nSamples-1:
         if debug>0:
-            print "End of file reached, jumping back to start"
+            print("End of file reached, jumping back to start")
         begsample = 0
         endsample = blocksize-1
         block     = 0
 
     if patch.getint('playback', 'rewind', default=0):
         if debug>0:
-            print "Rewind pressed, jumping back to start of file"
+            print("Rewind pressed, jumping back to start of file")
         begsample = 0
         endsample = blocksize-1
         block     = 0
 
     if not patch.getint('playback', 'play', default=1):
         if debug>0:
-            print "Stopped"
+            print("Stopped")
         time.sleep(0.1);
         continue
 
     if patch.getint('playback', 'pause', default=0):
         if debug>0:
-            print "Paused"
+            print("Paused")
         time.sleep(0.1);
         continue
 
@@ -203,7 +203,7 @@ while True:
     start = time.time()
 
     if debug>0:
-        print "Playing block", block, 'from', begsample, 'to', endsample
+        print("Playing block", block, 'from', begsample, 'to', endsample)
 
     # copy the selected samples from the in-memory data
     D = A[begsample:endsample+1,:]
@@ -225,4 +225,4 @@ while True:
         time.sleep(naptime)
 
     if debug>0:
-        print "played", blocksize, "samples in", (time.time()-start)*1000, "ms"
+        print("played", blocksize, "samples in", (time.time()-start)*1000, "ms")

--- a/module/plotcontrol/plotcontrol.py
+++ b/module/plotcontrol/plotcontrol.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pyqtgraph.Qt import QtGui, QtCore
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import redis
 import argparse
 import numpy as np
@@ -50,14 +50,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -66,7 +66,7 @@ patch = EEGsynth.patch(config, r)
 # this determines how much debugging information gets printed
 debug = patch.getint('general', 'debug')
 
-input_name, input_variable = zip(*config.items('input'))
+input_name, input_variable = list(zip(*config.items('input')))
 
 # count total nr. of curves to be drawm
 curve_nrs = 0
@@ -75,7 +75,7 @@ for i in range(len(input_name)):
     for ii in range(len(temp)):
         curve_nrs += 1
 
-ylim_name, ylim_value = zip(*config.items('ylim'))
+ylim_name, ylim_value = list(zip(*config.items('ylim')))
 delay       = patch.getfloat('general', 'delay')
 historysize = int(patch.getfloat('general', 'window') / delay)
 secwindow   = patch.getfloat('general', 'window')
@@ -109,9 +109,9 @@ for iplot in range(len(input_name)):
         index = ylim_name.index(input_name[iplot])
         temp = ylim_value[index].split(",")
         inputplot[iplot].setRange(yRange=(int(temp[0]), int(temp[1])))
-        print "Setting Ylim according to user input"
+        print("Setting Ylim according to user input")
     except:
-        print "No Ylim giving, will let it flow"
+        print("No Ylim giving, will let it flow")
 
     # if input_name == ylim_name
     # if any(input_name in s for s in ylim_name):

--- a/module/plotsignal/plotsignal.py
+++ b/module/plotsignal/plotsignal.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pyqtgraph.Qt import QtGui, QtCore
-import ConfigParser  # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import redis
 import argparse
 import numpy as np
@@ -50,14 +50,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -115,31 +115,31 @@ try:
     ftc_host = patch.getstring('fieldtrip', 'hostname')
     ftc_port = patch.getint('fieldtrip', 'port')
     if debug > 0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ft_input = FieldTrip.Client()
     ft_input.connect(ftc_host, ftc_port)
     if debug > 0:
-        print "Connected to input FieldTrip buffer"
+        print("Connected to input FieldTrip buffer")
 except:
-    print "Error: cannot connect to input FieldTrip buffer"
+    print("Error: cannot connect to input FieldTrip buffer")
     exit()
 
 hdr_input = None
 start = time.time()
 while hdr_input is None:
     if debug > 0:
-        print "Waiting for data to arrive..."
+        print("Waiting for data to arrive...")
     if (time.time() - start) > timeout:
-        print "Error: timeout while waiting for data"
+        print("Error: timeout while waiting for data")
         raise SystemExit
     hdr_input = ft_input.getHeader()
     time.sleep(0.2)
 
 if debug > 0:
-    print "Data arrived"
+    print("Data arrived")
 if debug > 1:
-    print hdr_input
-    print hdr_input.labels
+    print(hdr_input)
+    print(hdr_input.labels)
 
 # read variables from ini/redis
 chanarray = patch.getint('arguments', 'channels', multiple=True)
@@ -208,7 +208,7 @@ def update():
     endsample = (last_index - 1)
 
     if debug > 0:
-        print "reading from sample %d to %d" % (begsample, endsample)
+        print("reading from sample %d to %d" % (begsample, endsample))
 
     data = ft_input.getData([begsample, endsample])
 

--- a/module/plotspectral/plotspectral.py
+++ b/module/plotspectral/plotspectral.py
@@ -21,7 +21,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pyqtgraph.Qt import QtGui, QtCore
-import ConfigParser  # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import redis
 import argparse
 import numpy as np
@@ -51,14 +51,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -89,31 +89,31 @@ try:
     ftc_host = patch.getstring('fieldtrip', 'hostname')
     ftc_port = patch.getint('fieldtrip', 'port')
     if debug > 0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ft_input = FieldTrip.Client()
     ft_input.connect(ftc_host, ftc_port)
     if debug > 0:
-        print "Connected to input FieldTrip buffer"
+        print("Connected to input FieldTrip buffer")
 except:
-    print "Error: cannot connect to input FieldTrip buffer"
+    print("Error: cannot connect to input FieldTrip buffer")
     exit()
 
 hdr_input = None
 start = time.time()
 while hdr_input is None:
     if debug > 0:
-        print "Waiting for data to arrive..."
+        print("Waiting for data to arrive...")
     if (time.time() - start) > timeout:
-        print "Error: timeout while waiting for data"
+        print("Error: timeout while waiting for data")
         raise SystemExit
     hdr_input = ft_input.getHeader()
     time.sleep(0.2)
 
 if debug > 0:
-    print "Data arrived"
+    print("Data arrived")
 if debug > 1:
-    print hdr_input
-    print hdr_input.labels
+    print(hdr_input)
+    print(hdr_input.labels)
 
 # read variables from ini/redis
 chanarray = patch.getint('arguments', 'channels', multiple=True)
@@ -237,7 +237,7 @@ def update():
     data = ft_input.getData([begsample, endsample])
 
     if debug>0:
-        print "reading from sample %d to %d" % (begsample, endsample)
+        print("reading from sample %d to %d" % (begsample, endsample))
 
     # demean and detrend data before filtering to reduce edge artefacts and center timecourse
     data = detrend(data, axis=0)

--- a/module/plottrigger/plottrigger.py
+++ b/module/plottrigger/plottrigger.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pyqtgraph.Qt import QtGui, QtCore
-import ConfigParser  # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import redis
 import argparse
 import numpy as np
@@ -48,14 +48,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -95,7 +95,7 @@ class TriggerThread(threading.Thread):
                     break
                 if item['channel']==self.redischannel:
                     if debug>1:
-                        print item
+                        print(item)
                     lock.acquire()
                     now = time.time()
                     val = float(item['data'])
@@ -115,7 +115,7 @@ for i in range(1, 17):
         this = TriggerThread(patch.getstring('gate', name), i)
         gate.append(this)
         if debug>1:
-            print name, 'OK'
+            print(name, 'OK')
 
 # start the thread for each of the notes
 for thread in gate:
@@ -183,7 +183,7 @@ timer.start(int(round(delay * 1000)))     # in milliseconds
 # Start
 QtGui.QApplication.instance().exec_()
 
-print 'Closing threads'
+print('Closing threads')
 for thread in gate:
     thread.stop()
 r.publish('PLOTTRIGGER_UNBLOCK', 1)

--- a/module/postprocessing/postprocessing.py
+++ b/module/postprocessing/postprocessing.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from numpy import log, log2, log10, exp, power, sqrt, mean, median, var, std
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -47,14 +47,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -64,8 +64,8 @@ patch = EEGsynth.patch(config, r)
 debug = patch.getint('general','debug')
 
 # get the input and output options
-input_name, input_variable = zip(*config.items('input'))
-output_name, output_equation = zip(*config.items('output'))
+input_name, input_variable = list(zip(*config.items('input')))
+output_name, output_equation = list(zip(*config.items('output')))
 
 def sanitize(equation):
     equation = equation.replace('(', '( ')
@@ -81,13 +81,13 @@ def sanitize(equation):
 output_equation = [sanitize(equation) for equation in output_equation]
 
 if debug>0:
-    print '===== input variables ====='
+    print('===== input variables =====')
     for name,variable in zip(input_name, input_variable):
-        print name, '=', variable
-    print '===== output equations ====='
+        print(name, '=', variable)
+    print('===== output equations =====')
     for name,equation in zip(output_name, output_equation):
-        print name, '=', equation
-    print '============================'
+        print(name, '=', equation)
+    print('============================')
 
 
 while True:
@@ -109,7 +109,7 @@ while True:
             try:
                 val = eval(equation)
                 if debug>1:
-                    print key, '=', equation, '=', val
+                    print(key, '=', equation, '=', val)
                 patch.setvalue(key, val)
             except:
-                print 'Error in evaluation'
+                print('Error in evaluation')

--- a/module/quantizer/quantizer.py
+++ b/module/quantizer/quantizer.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -43,14 +43,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -67,8 +67,8 @@ output_scale  = patch.getfloat('output', 'scale', default=0.00787401574803149606
 output_offset = patch.getfloat('output', 'offset', default=0)
 
 # get the input and output options
-input_channel, input_name = map(list, zip(*config.items('input')))
-output_name, output_value = map(list, zip(*config.items('quantization')))
+input_channel, input_name = list(map(list, list(zip(*config.items('input')))))
+output_name, output_value = list(map(list, list(zip(*config.items('quantization')))))
 
 # remove the scale and offset from the input list
 del input_channel[input_channel.index('scale')]
@@ -94,20 +94,20 @@ while True:
     time.sleep(patch.getfloat('general', 'delay'))
 
     if debug>0:
-        print '----------------------------------------'
+        print('----------------------------------------')
 
     for channel, name in zip(input_channel, input_name):
         val = patch.getfloat('input', channel)
         if val is None:
             if debug>0:
-                print name, 'not found'
+                print(name, 'not found')
             pass
         else:
             # map the Redis values to the internally used values
             val = EEGsynth.rescale(val, slope=input_scale, offset=input_offset)
             # look up the nearest index of the input_value vector
             if debug>0:
-                print name, '=', val
+                print(name, '=', val)
             idx = find_nearest_idx(input_value, val)
             for qname, qvalue in zip(output_name, output_value):
                 key = '{}.{}'.format(name, qname)
@@ -118,7 +118,7 @@ while True:
                     # take the last value from the output list
                     val = qvalue[-1]
                 if debug>0:
-                    print key, '=', val
+                    print(key, '=', val)
                 # map the internally used values to Redis values
                 val = EEGsynth.rescale(val, slope=output_scale, offset=output_offset)
                 patch.setvalue(key, val)

--- a/module/recordcontrol/recordcontrol.py
+++ b/module/recordcontrol/recordcontrol.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser  # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import datetime
 import numpy as np
@@ -52,14 +52,14 @@ parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder,
                                                             os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -88,14 +88,14 @@ while True:
 
     if recording and not patch.getint('recording', 'record'):
         if debug > 0:
-            print "Recording disabled - closing", fname
+            print("Recording disabled - closing", fname)
         f.close()
         recording = False
         continue
 
     if not recording and not patch.getint('recording', 'record'):
         if debug > 0:
-            print "Recording is not enabled"
+            print("Recording is not enabled")
         time.sleep(1)
 
     if not recording and patch.getint('recording', 'record'):
@@ -120,11 +120,11 @@ while True:
 
         # search-and-replace to reduce the length of the channel labels
         for replace in config.items('replace'):
-            print replace
+            print(replace)
             for i in range(len(channelz)):
                 channelz[i] = channelz[i].replace(replace[0], replace[1])
         for s, z in zip(channels, channelz):
-            print "Writing control value", s, "as channel", z
+            print("Writing control value", s, "as channel", z)
 
         # these are required for mapping floating point values onto 16 bit integers
         physical_min = patch.getfloat('recording', 'physical_min')
@@ -132,7 +132,7 @@ while True:
 
         # write the header to file
         if debug > 0:
-            print "Opening", fname
+            print("Opening", fname)
         if fileformat == 'edf':
             # construct the header
             meas_info = {}
@@ -179,9 +179,9 @@ while True:
             patch.setvalue("recordcontrol.synchronize", sample)
 
         if debug > 1:
-            print "Writing", D
+            print("Writing", D)
         elif debug > 0:
-            print "Writing sample", sample, "as", np.shape(D)
+            print("Writing sample", sample, "as", np.shape(D))
 
         if fileformat == 'edf':
             f.writeBlock(D)

--- a/module/recordtrigger/recordtrigger.py
+++ b/module/recordtrigger/recordtrigger.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import datetime
 import os
@@ -46,14 +46,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -99,16 +99,16 @@ class TriggerThread(threading.Thread):
                         f.write("%s\t%g\t%s\n" % (self.redischannel, val, timestamp))
                         lock.release()
                         if debug>0:
-                            print("%s\t%g\t%s" % (self.redischannel, val, timestamp))
+                            print(("%s\t%g\t%s" % (self.redischannel, val, timestamp)))
 
 # create the background threads that deal with the triggers
 trigger = []
 if debug>1:
-    print "Setting up threads for each trigger"
+    print("Setting up threads for each trigger")
 for item in config.items('trigger'):
         trigger.append(TriggerThread(item[0]))
         if debug>1:
-            print item[0], 'OK'
+            print(item[0], 'OK')
 
 # start the thread for each of the triggers
 for thread in trigger:
@@ -120,14 +120,14 @@ try:
 
         if recording and not patch.getint('recording', 'record'):
             if debug>0:
-                print "Recording disabled - closing", fname
+                print("Recording disabled - closing", fname)
             f.close()
             recording = False
             continue
 
         if not recording and not patch.getint('recording', 'record'):
             if debug>0:
-                print "Recording is not enabled"
+                print("Recording is not enabled")
             time.sleep(1)
 
         if not recording and patch.getint('recording', 'record'):
@@ -139,7 +139,7 @@ try:
                 ext = '.' + fileformat
             fname = name + '_' + datetime.datetime.now().strftime("%Y.%m.%d_%H.%M.%S") + ext
             if debug>0:
-                print "Recording enabled - opening", fname
+                print("Recording enabled - opening", fname)
             f = open(fname, 'w')
             f.write("event\tvalue\ttimestamp\n")
             f.flush()
@@ -147,9 +147,9 @@ try:
 
 except KeyboardInterrupt:
     if not f.closed:
-        print 'Closing file'
+        print('Closing file')
         f.close()
-    print 'Closing threads'
+    print('Closing threads')
     for thread in trigger:
         thread.stop()
     r.publish('RECORDTRIGGER_UNBLOCK', 1)

--- a/module/rms/rms.py
+++ b/module/rms/rms.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from nilearn import signal
-import ConfigParser  # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import math
 import multiprocessing
@@ -48,14 +48,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -71,31 +71,31 @@ try:
     ftc_host = patch.getstring('fieldtrip', 'hostname')
     ftc_port = patch.getint('fieldtrip', 'port')
     if debug > 0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ftc = FieldTrip.Client()
     ftc.connect(ftc_host, ftc_port)
     if debug > 0:
-        print "Connected to FieldTrip buffer"
+        print("Connected to FieldTrip buffer")
 except:
-    print "Error: cannot connect to FieldTrip buffer"
+    print("Error: cannot connect to FieldTrip buffer")
     exit()
 
 hdr_input = None
 start = time.time()
 while hdr_input is None:
     if debug > 0:
-        print "Waiting for data to arrive..."
+        print("Waiting for data to arrive...")
     if (time.time() - start) > timeout:
-        print "Error: timeout while waiting for data"
+        print("Error: timeout while waiting for data")
         raise SystemExit
     hdr_input = ftc.getHeader()
     time.sleep(0.2)
 
 if debug > 0:
-    print "Data arrived"
+    print("Data arrived")
 if debug > 1:
-    print hdr_input
-    print hdr_input.labels
+    print(hdr_input)
+    print(hdr_input.labels)
 
 channel_items = config.items('input')
 channame = []
@@ -117,7 +117,7 @@ while True:
 
     hdr_input = ftc.getHeader()
     if (hdr_input.nSamples - 1) < endsample:
-        print "Error: buffer reset detected"
+        print("Error: buffer reset detected")
         raise SystemExit
 
     endsample = hdr_input.nSamples - 1
@@ -136,7 +136,7 @@ while True:
         rms[i] = math.sqrt(rms[i] / len(chanvec))
 
     if debug > 0:
-        print "rms =", rms
+        print("rms =", rms)
 
     for name, val in zip(channame, rms):
         # send it as control value: prefix.channelX=val

--- a/module/sequencer/sequencer.py
+++ b/module/sequencer/sequencer.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser  # this is version 2.x specific,on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import math
 import numpy as np
@@ -45,14 +45,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -78,7 +78,7 @@ lock = threading.Lock()
 # this can be used to selectively show parameters that have changed
 def show_change(key, val):
     if (key not in show_change.previous) or (show_change.previous[key]!=val):
-        print key, "=", val
+        print(key, "=", val)
         show_change.previous[key] = val
         return True
     else:
@@ -152,7 +152,7 @@ class SequenceThread(threading.Thread):
                             key = '%s%03d' % (self.key, val)
                             patch.setvalue(key, 1., duration=self.duration*self.steptime)
                         if debug>0:
-                            print "step %2d :" % (self.step + 1), self.key, "=", val
+                            print("step %2d :" % (self.step + 1), self.key, "=", val)
                         # increment to the next step
                         self.step = (self.step + 1) % len(self.sequence)
 
@@ -183,7 +183,7 @@ try:
         now = time.time()
 
         if debug > 1:
-            print 'loop'
+            print('loop')
 
         # the active sequence is specified as an integer between 0 and 127
         active = patch.getfloat('sequence', 'active', default=0)
@@ -222,11 +222,11 @@ try:
 
 except KeyboardInterrupt:
     try:
-        print "Disabling last note"
+        print("Disabling last note")
         patch.setvalue(key, 0.)
     except:
         pass
-    print "Closing threads"
+    print("Closing threads")
     sequencethread.stop()
     r.publish('SEQUENCER_UNBLOCK', 1)
     sequencethread.join()

--- a/module/sonification/sonification.py
+++ b/module/sonification/sonification.py
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from copy import copy
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import numpy as np
 import os
@@ -43,14 +43,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -77,45 +77,45 @@ try:
     ftc_host = patch.getstring('input_fieldtrip', 'hostname')
     ftc_port = patch.getint('input_fieldtrip', 'port')
     if debug > 0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ft_input = FieldTrip.Client()
     ft_input.connect(ftc_host, ftc_port)
     if debug > 0:
-        print "Connected to input FieldTrip buffer"
+        print("Connected to input FieldTrip buffer")
 except:
-    print "Error: cannot connect to input FieldTrip buffer"
+    print("Error: cannot connect to input FieldTrip buffer")
     exit()
 
 try:
     ftc_host = patch.getstring('output_fieldtrip', 'hostname')
     ftc_port = patch.getint('output_fieldtrip', 'port')
     if debug > 0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ft_output = FieldTrip.Client()
     ft_output.connect(ftc_host, ftc_port)
     if debug > 0:
-        print "Connected to output FieldTrip buffer"
+        print("Connected to output FieldTrip buffer")
 except:
-    print "Error: cannot connect to output FieldTrip buffer"
+    print("Error: cannot connect to output FieldTrip buffer")
     exit()
 
 hdr_input = None
 start = time.time()
 while hdr_input is None:
     if debug > 0:
-        print "Waiting for data to arrive..."
+        print("Waiting for data to arrive...")
     if (time.time()-start) > timeout:
-        print "Error: timeout while waiting for data"
+        print("Error: timeout while waiting for data")
         raise SystemExit
     hdr_input = ft_input.getHeader()
     time.sleep(0.2)
 
 if debug > 0:
-    print "Data arrived"
+    print("Data arrived")
 
 if debug > 1:
-    print "input nsample", hdr_input.nSamples
-    print "input nchan", hdr_input.nChannels
+    print("input nsample", hdr_input.nSamples)
+    print("input nchan", hdr_input.nChannels)
 
 # set up the output data stream
 if len(right)>0:
@@ -127,8 +127,8 @@ else:
 hdr_output = ft_output.getHeader()
 
 if debug > 1:
-    print "output nsample", hdr_output.nSamples
-    print "output nchan", hdr_output.nChannels
+    print("output nsample", hdr_output.nSamples)
+    print("output nchan", hdr_output.nChannels)
 
 # this is the number of samples per input and per output block
 nInput = int(round(window*hdr_input.fSample))
@@ -191,12 +191,12 @@ for i in range(0,len(right)):
 
 
 if debug>0:
-    print "left audio channels", left
-    print "left audio frequencies", left_f
-    print "right audio channels", right
-    print "right audio frequencies", right_f
+    print("left audio channels", left)
+    print("left audio frequencies", left_f)
+    print("right audio channels", right)
+    print("right audio frequencies", right_f)
 
-print "STARTING STREAM"
+print("STARTING STREAM")
 
 while True:
 
@@ -206,10 +206,10 @@ while True:
         time.sleep(patch.getfloat('general', 'delay'))
         hdr_input = ft_input.getHeader()
         if hdr_input.nSamples < begsample:
-            print "Error: buffer reset detected"
+            print("Error: buffer reset detected")
             raise SystemExit
         if (time.time()-start) > timeout:
-            print "Error: timeout while waiting for data"
+            print("Error: timeout while waiting for data")
             raise SystemExit
 
     # get the input data
@@ -222,7 +222,7 @@ while True:
     tim_input = np.linspace(begtime, endtime, nInput, endpoint=False)
     tim_output = np.linspace(begtime, endtime, nOutput, endpoint=False)
 
-    for chan, i in zip(left, range(len(left))):
+    for chan, i in zip(left, list(range(len(left)))):
         # interpolate each channel onto the output sampling rate
         vec_output = np.interp(tim_output, tim_input, dat_input[:, chan-1])
         # multiply with the modulating signal
@@ -232,7 +232,7 @@ while True:
         # add it to the output
         dat_output[:,0] += vec_output
 
-    for chan, i in zip(right, range(len(right))):
+    for chan, i in zip(right, list(range(len(right)))):
         # interpolate each channel onto the output sampling rate
         vec_output = np.interp(tim_output, tim_input, dat_input[:, chan-1])
         # multiply with the modulating signal
@@ -267,7 +267,7 @@ while True:
     #    nOutput = int(round(nOutput))
 
     if debug>0:
-        print "wrote", nInput, "->", nOutput, "samples in", duration*1000, "ms"
+        print("wrote", nInput, "->", nOutput, "samples in", duration*1000, "ms")
 
     # shift to the next block of data
     begsample += nInput

--- a/module/spectral/spectral.py
+++ b/module/spectral/spectral.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import math
 import multiprocessing
@@ -47,14 +47,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -70,31 +70,31 @@ try:
     ftc_host = patch.getstring('fieldtrip','hostname')
     ftc_port = patch.getint('fieldtrip','port')
     if debug>0:
-        print 'Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port)
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
     ftc = FieldTrip.Client()
     ftc.connect(ftc_host, ftc_port)
     if debug>0:
-        print "Connected to FieldTrip buffer"
+        print("Connected to FieldTrip buffer")
 except:
-    print "Error: cannot connect to FieldTrip buffer"
+    print("Error: cannot connect to FieldTrip buffer")
     exit()
 
 hdr_input = None
 start = time.time()
 while hdr_input is None:
     if debug>0:
-        print "Waiting for data to arrive..."
+        print("Waiting for data to arrive...")
     if (time.time()-start)>timeout:
-        print "Error: timeout while waiting for data"
+        print("Error: timeout while waiting for data")
         raise SystemExit
     hdr_input = ftc.getHeader()
     time.sleep(0.2)
 
 if debug>0:
-    print "Data arrived"
+    print("Data arrived")
 if debug>1:
-    print hdr_input
-    print hdr_input.labels
+    print(hdr_input)
+    print(hdr_input.labels)
 
 channel_items = config.items('input')
 channame = []
@@ -105,7 +105,7 @@ for item in channel_items:
     chanindx.append(patch.getint('input', item[0])-1)
 
 if debug>0:
-    print channame, chanindx
+    print(channame, chanindx)
 
 prefix      = patch.getstring('output', 'prefix')
 window      = patch.getfloat('processing','window')  # in seconds
@@ -114,8 +114,8 @@ taper       = np.hanning(window)
 frequency   = np.fft.rfftfreq(window, 1.0/hdr_input.fSample)
 
 if debug>2:
-    print 'taper     = ', taper
-    print 'frequency = ', frequency
+    print('taper     = ', taper)
+    print('frequency = ', frequency)
 
 begsample = -1
 endsample = -1
@@ -131,16 +131,16 @@ while True:
         # channel numbers are one-offset in the ini file, zero-offset in the code
         lohi = patch.getfloat('band', item[0], multiple=True)
         if debug>2:
-            print item[0], lohi
+            print(item[0], lohi)
         bandname.append(item[0])
         bandlo.append(lohi[0])
         bandhi.append(lohi[1])
     if debug>0:
-        print bandname, bandlo, bandhi
+        print(bandname, bandlo, bandhi)
 
     hdr_input = ftc.getHeader()
     if (hdr_input.nSamples-1)<endsample:
-        print "Error: buffer reset detected"
+        print("Error: buffer reset detected")
         raise SystemExit
     endsample = hdr_input.nSamples - 1
     if endsample<window:
@@ -185,7 +185,7 @@ while True:
             i+=1
 
     if debug>1:
-        print power
+        print(power)
 
     i = 0
     for chan in channame:

--- a/module/synthesizer/synthesizer.py
+++ b/module/synthesizer/synthesizer.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser  # this is version 2.x specific,on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import math
 import multiprocessing
@@ -45,14 +45,14 @@ parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder,
                                                             os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -70,20 +70,20 @@ blocksize = patch.getint('audio', 'blocksize')
 nchans = 1
 format = p.get_format_from_width(2)  # the desired sample width in bytes (1, 2, 3, or 4)
 
-print '------------------------------------------------------------------'
+print('------------------------------------------------------------------')
 info = p.get_host_api_info_by_index(0)
-print info
-print '------------------------------------------------------------------'
+print(info)
+print('------------------------------------------------------------------')
 for i in range(info.get('deviceCount')):
     if p.get_device_info_by_host_api_device_index(0, i).get('maxInputChannels') > 0:
-        print "Input  Device id ", i, " - ", p.get_device_info_by_host_api_device_index(0, i).get('name')
+        print("Input  Device id ", i, " - ", p.get_device_info_by_host_api_device_index(0, i).get('name'))
     if p.get_device_info_by_host_api_device_index(0, i).get('maxOutputChannels') > 0:
-        print "Output Device id ", i, " - ", p.get_device_info_by_host_api_device_index(0, i).get('name')
-print '------------------------------------------------------------------'
+        print("Output Device id ", i, " - ", p.get_device_info_by_host_api_device_index(0, i).get('name'))
+print('------------------------------------------------------------------')
 devinfo = p.get_device_info_by_index(device)
-print "Selected device is", devinfo['name']
-print devinfo
-print '------------------------------------------------------------------'
+print("Selected device is", devinfo['name'])
+print(devinfo)
+print('------------------------------------------------------------------')
 
 stream = p.open(format=format,
                 channels=nchans,
@@ -115,7 +115,7 @@ class TriggerThread(threading.Thread):
             for item in pubsub.listen():
                 if not self.running or not item['type'] == 'message':
                     break
-                print item['channel'], "=", item['data']
+                print(item['channel'], "=", item['data'])
                 lock.acquire()
                 self.last = self.time
                 lock.release()
@@ -215,19 +215,19 @@ class ControlThread(threading.Thread):
             self.vca_envelope = vca_envelope
             lock.release()
             if debug > 2:
-                print '----------------------------------'
-                print 'vco_pitch      =', vco_pitch
-                print 'vco_sin        =', vco_sin
-                print 'vco_tri        =', vco_tri
-                print 'vco_saw        =', vco_saw
-                print 'vco_sqr        =', vco_sqr
-                print 'lfo_depth      =', lfo_depth
-                print 'lfo_frequency  =', lfo_frequency
-                print 'adsr_attack    =', adsr_attack
-                print 'adsr_decay     =', adsr_decay
-                print 'adsr_sustain   =', adsr_sustain
-                print 'adsr_release   =', adsr_release
-                print 'vca_envelope   =', vca_envelope
+                print('----------------------------------')
+                print('vco_pitch      =', vco_pitch)
+                print('vco_sin        =', vco_sin)
+                print('vco_tri        =', vco_tri)
+                print('vco_saw        =', vco_saw)
+                print('vco_sqr        =', vco_sqr)
+                print('lfo_depth      =', lfo_depth)
+                print('lfo_frequency  =', lfo_frequency)
+                print('adsr_attack    =', adsr_attack)
+                print('adsr_decay     =', adsr_decay)
+                print('adsr_sustain   =', adsr_sustain)
+                print('adsr_release   =', adsr_release)
+                print('vca_envelope   =', vca_envelope)
 
 
 # start the background thread that deals with control value changes
@@ -248,7 +248,7 @@ try:
         ################################################################################
         BUFFER = ''
 
-        for t in xrange(offset, offset + blocksize):
+        for t in range(offset, offset + blocksize):
             # update the time for the trigger detection
 
             lock.acquire()
@@ -311,7 +311,7 @@ try:
         offset = offset + blocksize
 
 except KeyboardInterrupt:
-    print "Closing threads"
+    print("Closing threads")
     control.stop()
     control.join()
     trigger.stop()

--- a/module/volcabass/volcabass.py
+++ b/module/volcabass/volcabass.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import mido
 import os
@@ -44,14 +44,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -96,7 +96,7 @@ class TriggerThread(threading.Thread):
                     val = EEGsynth.limit(val, 0, 127)
                     val = int(val)
                     if debug>1:
-                        print item['channel'], "=", val
+                        print(item['channel'], "=", val)
                     msg = mido.Message('note_on', note=self.note, velocity=val, channel=midichannel)
                     lock.acquire()
                     outputport.send(msg)
@@ -110,7 +110,7 @@ for name, code in zip(note_name, note_code):
         this = TriggerThread(patch.getstring('note', name), code)
         trigger.append(this)
         if debug>1:
-            print name, 'OK'
+            print(name, 'OK')
 
 # start the thread for each of the notes
 for thread in trigger:
@@ -143,13 +143,13 @@ try:
             val = int(val)
             msg = mido.Message('control_change', control=cmd, value=val, channel=midichannel)
             if debug>1:
-                print cmd, val, name
+                print(cmd, val, name)
             lock.acquire()
             outputport.send(msg)
             lock.release()
 
 except KeyboardInterrupt:
-    print "Closing threads"
+    print("Closing threads")
     for thread in trigger:
         thread.stop()
     r.publish('VOLCABASS_UNBLOCK', 1)

--- a/module/volcabeats/volcabeats.py
+++ b/module/volcabeats/volcabeats.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import mido
 import os
@@ -44,14 +44,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -102,7 +102,7 @@ class TriggerThread(threading.Thread):
                     val = EEGsynth.limit(val, 0, 127)
                     val = int(val)
                     if debug>1:
-                        print item['channel'], "=", val
+                        print(item['channel'], "=", val)
                     msg = mido.Message('note_on', note=self.note, velocity=val, channel=midichannel)
                     lock.acquire()
                     outputport.send(msg)
@@ -116,7 +116,7 @@ for name, code in zip(note_name, note_code):
         this = TriggerThread(patch.getstring('note', name), code)
         trigger.append(this)
         if debug>1:
-            print name, 'OK'
+            print(name, 'OK')
 
 # start the thread for each of the notes
 for thread in trigger:
@@ -149,13 +149,13 @@ try:
             val = int(val)
             msg = mido.Message('control_change', control=cmd, value=val, channel=midichannel)
             if debug>1:
-                print cmd, val, name
+                print(cmd, val, name)
             lock.acquire()
             outputport.send(msg)
             lock.release()
 
 except KeyboardInterrupt:
-    print "Closing threads"
+    print("Closing threads")
     for thread in trigger:
         thread.stop()
     r.publish('VOLCABEATS_UNBLOCK', 1)

--- a/module/volcakeys/volcakeys.py
+++ b/module/volcakeys/volcakeys.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import ConfigParser # this is version 2.x specific, on version 3.x it is called "configparser" and has a different API
+import configparser
 import argparse
 import mido
 import os
@@ -44,14 +44,14 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder, os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
 args = parser.parse_args()
 
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(args.inifile)
 
 try:
     r = redis.StrictRedis(host=config.get('redis','hostname'), port=config.getint('redis','port'), db=0)
     response = r.client_list()
 except redis.ConnectionError:
-    print "Error: cannot connect to redis server"
+    print("Error: cannot connect to redis server")
     exit()
 
 # combine the patching from the configuration file and Redis
@@ -96,7 +96,7 @@ class TriggerThread(threading.Thread):
                     val = EEGsynth.limit(val, 0, 127)
                     val = int(val)
                     if debug>1:
-                        print item['channel'], "=", val
+                        print(item['channel'], "=", val)
                     msg = mido.Message('note_on', note=self.note, velocity=val, channel=midichannel)
                     lock.acquire()
                     outputport.send(msg)
@@ -110,7 +110,7 @@ for name, code in zip(note_name, note_code):
         this = TriggerThread(patch.getstring('note', name), code)
         trigger.append(this)
         if debug>1:
-            print name, 'OK'
+            print(name, 'OK')
 
 # start the thread for each of the notes
 for thread in trigger:
@@ -143,13 +143,13 @@ try:
             val = int(val)
             msg = mido.Message('control_change', control=cmd, value=val, channel=midichannel)
             if debug>1:
-                print cmd, val, name
+                print(cmd, val, name)
             lock.acquire()
             outputport.send(msg)
             lock.release()
 
 except KeyboardInterrupt:
-    print "Closing threads"
+    print("Closing threads")
     for thread in trigger:
         thread.stop()
     r.publish('VOLCAKEYS_UNBLOCK', 1)


### PR DESCRIPTION
important for #309 is that the existing support for Python 2.7 does not break. 

After making the changes I tested it with one patch and python 2.7, and it seemed all to work. I did not have some hardware attached (launchcontrol, cvgate, eeg), so cannot confirm that everything works. 

There was one module (geomixer) that caused a problem with end-of-line differences and print, I solved that according to https://stackoverflow.com/questions/493386/how-to-print-without-newline-or-space.

@stephenwhitmarsh would you mind pulling this branch and testing it against your patch/setup, i.e. with your current python version and all of your current pip-installed packages? If this PR does not break things, it would already be a good step to improving support for Python 3. 