### PR TITLE
implement support for LSL

### DIFF
--- a/module/lsl2ft/README.md
+++ b/module/lsl2ft/README.md
@@ -1,0 +1,7 @@
+# lsl2ft
+
+The purpose of this module is to read data from an LSL stream and to write it to the FieldTrip buffer. Other modules can read it from the buffer and analyze/convert/process it.
+
+# Requirements
+
+The FieldTrip buffer should be running prior to starting this module.

--- a/module/lsl2ft/lsl2ft.ini
+++ b/module/lsl2ft/lsl2ft.ini
@@ -1,0 +1,16 @@
+[general]
+debug=1
+delay=0.5
+
+[fieldtrip]
+hostname=localhost
+port=1972
+
+[redis]
+hostname=localhost
+port=6379
+
+[lsl]
+; this can be used to select the desired stream in case there are multiple
+name=
+type=EEG

--- a/module/lsl2ft/lsl2ft.py
+++ b/module/lsl2ft/lsl2ft.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+# Lsl2ft reads data from an LSL stream and writes it to a FieldTrip buffer
+#
+# This software is part of the EEGsynth project, see https://github.com/eegsynth/eegsynth
+#
+# Copyright (C) 2019 EEGsynth project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import configparser
+import argparse
+import numpy as np
+import os
+import redis
+import sys
+import time
+import pylsl as lsl
+
+if hasattr(sys, 'frozen'):
+    basis = sys.executable
+elif sys.argv[0] != '':
+    basis = sys.argv[0]
+else:
+    basis = './'
+installed_folder = os.path.split(basis)[0]
+
+# eegsynth/lib contains shared modules
+sys.path.insert(0, os.path.join(installed_folder, '../../lib'))
+import EEGsynth
+import FieldTrip
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-i", "--inifile", default=os.path.join(installed_folder,
+                                                            os.path.splitext(os.path.basename(__file__))[0] + '.ini'), help="optional name of the configuration file")
+args = parser.parse_args()
+
+config = configparser.ConfigParser(inline_comment_prefixes=('#', ';'))
+config.read(args.inifile)
+
+try:
+    r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0)
+    response = r.client_list()
+except redis.ConnectionError:
+    print("Error: cannot connect to redis server")
+    exit()
+
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+del config
+
+# this determines how much debugging information gets printed
+debug    = patch.getint('general', 'debug')
+delay    = patch.getint('general', 'delay')
+lsl_name = patch.getstring('lsl', 'name')
+lsl_type = patch.getstring('lsl', 'type')
+
+try:
+    ftc_host = patch.getstring('fieldtrip', 'hostname')
+    ftc_port = patch.getint('fieldtrip', 'port')
+    if debug > 0:
+        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
+    ft_output = FieldTrip.Client()
+    ft_output.connect(ftc_host, ftc_port)
+    if debug > 0:
+        print("Connected to output FieldTrip buffer")
+except:
+    print("Error: cannot connect to output FieldTrip buffer")
+    exit()
+
+# first resolve an EEG stream on the lab network
+print("looking for an LSL stream...")
+streams = lsl.resolve_streams()
+selected = []
+
+for stream in streams:
+    inlet           = lsl.StreamInlet(stream)
+    name            = inlet.info().name()
+    type            = inlet.info().type()
+    channel_count   = inlet.info().channel_count()
+    nominal_srate   = inlet.info().nominal_srate()
+    channel_format  = inlet.info().channel_format()
+    source_id       = inlet.info().source_id()
+    # determine whether this stream should be further processed
+    match = True
+    if len(lsl_name):
+        match = match and lsl_name==name
+    if len(lsl_type):
+        match = match and lsl_type==type
+    if match:
+        # select this stream for further processing
+        selected.append(stream)
+        print('-------- STREAM(*) ------')
+    else:
+        print('-------- STREAM ---------')
+    if debug>0:
+        print("name", name)
+        print("type", type)
+        print("channel_count", channel_count)
+        print("nominal_srate", nominal_srate)
+        print("channel_format", channel_format)
+        print("source_id", source_id)
+    print('-------------------------')
+
+# create a new inlet from the first (and probably only) selected stream
+inlet = lsl.StreamInlet(selected[0])
+channel_count = inlet.info().channel_count()
+nominal_srate = inlet.info().nominal_srate()
+
+ft_output.putHeader(channel_count, nominal_srate, FieldTrip.DATATYPE_FLOAT32)
+
+# this is used for feedback
+start = time.time()
+count = 0
+
+print("STARTING STREAM")
+while True:
+    chunk, timestamps = inlet.pull_chunk()
+    if timestamps:
+        dat = np.asarray(chunk, dtype=np.float32)
+        count += dat.shape[0]
+        ft_output.putData(dat)
+        if debug>0 and (start-time.time())>delay:
+            print("processed %d samples" % count)
+            start = time.time()

--- a/module/plotsignal/plotsignal.ini
+++ b/module/plotsignal/plotsignal.ini
@@ -19,10 +19,11 @@ height=480
 [arguments]
 channels=1,2,3      ; channel numbers to plot, channel index starts with 1
 window=5            ; size of data window to plot (minus clipsize on both sides)
-clipsize=0.4        ; clipping of timecourse edges to remove edge artefacts (s)
+clipsize=0.0        ; clipping of timecourse edges to remove edge artefacts (s)
 stepsize=0.1        ; update time (s)
 learning_rate=0.2   ; learning rate for smooth y-axis transitions (float 0-1)
+demean=0            ; boolean, 0 or 1
 detrend=1           ; boolean, 0 or 1
-bandpass=5-30       ; bandpass filter range before plotting (Hz)
-; lowpass=45        ; lowpass filter range before plotting (Hz)
-; highpass=5        ; highpass filter range before plotting (Hz)
+lowpass=45          ; lowpass filter range before plotting (Hz)
+; highpass=1        ; highpass filter range before plotting (Hz)
+; bandpass=1-45     ; bandpass filter range before plotting (Hz)

--- a/module/plotsignal/plotsignal.py
+++ b/module/plotsignal/plotsignal.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-# Plotsignal plots data from the FieldTrip buffer. Currently it also includes user-defined filtering
+# Plotsignal plots the last segment of data from the FieldTrip buffer.
+# It also includes some user-defined filtering.
 #
 # This software is part of the EEGsynth project, see https://github.com/eegsynth/eegsynth
 #
@@ -238,7 +239,7 @@ def update():
         channr = int(chanarray[ichan])
 
         # time axis
-        timeaxis = np.linspace(-window / hdr_input.fSample, 0, len(data))
+        timeaxis = np.linspace(-(window-2*clipsize) / hdr_input.fSample, 0, len(data))
 
         # update timecourses
         curve[ichan].setData(timeaxis, data[:, channr])


### PR DESCRIPTION
After reviewing and testing the Python support for all openbci boards, i.e. 
- cyton with and without wifi
- ganglion with and without wifi
I realized that the Python code is not stable and complete enough (yet). The only interface to the data streams that is consistent and that supports multiple OS platforms is the OpenBCI GUI.  It has under the "networking" widget the possibility to stream data over serial, udp, osc and lsl. This PR contains the lsl2ft module, which takes the LSL stream and copies it to the FT buffer.

Since LSL is also used in other systems, e.g. mBrainTrain, I think it is a useful addition in general. 
