### PR TITLE
ENH - implemented input and output handling of LSL markers

### DIFF
--- a/module/inputlsl/README.md
+++ b/module/inputlsl/README.md
@@ -1,0 +1,7 @@
+# InputLSL
+
+This module receives event messages from LabStreamingLayer (LSL) and sends them to Redis.
+
+Note that this module is explicitly designed for irregular string-valued LSL messages, not for data. If you want to process regularly sampled data such as EEG, you should use the lsl2ft module.
+
+A limitation of the LSL marker format is that it only contain a single string value. Under the `[lsl]` section you can specify by the format whether you want the LSL marker string to be interpreted as a string that becomes part of the Redis message, or as a numeric value.

--- a/module/inputlsl/inputlsl.ini
+++ b/module/inputlsl/inputlsl.ini
@@ -1,0 +1,21 @@
+[general]
+debug=2
+delay=0.05
+
+[redis]
+hostname=localhost
+port=6379
+
+[lsl]
+name=eegsynth
+type=Markers
+format=name     ; string or value, how to translate the LSL marker to Redis
+
+; in case the format is specified as "value", the following scale and offset are applied
+scale=0.00787401574803149606
+offset=0
+
+[output]
+; with format=name, the results will be written to Redis as "lsl.name.type.xxx" etc.
+; with format=value, the results will be written to Redis as "lsl.name.type" with the numeric value
+prefix=lsl

--- a/module/inputlsl/inputlsl.py
+++ b/module/inputlsl/inputlsl.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Lsl2ft reads data from an LSL stream and writes it to a FieldTrip buffer
+# This module translates LSL string markers to Redis control values and and events.
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
@@ -21,12 +21,12 @@
 
 import configparser
 import argparse
-import numpy as np
 import os
 import redis
 import sys
 import time
 import pylsl as lsl
+import numpy as np
 
 if hasattr(sys, 'frozen'):
     path = os.path.split(sys.executable)[0]
@@ -39,9 +39,8 @@ else:
     file = os.path.split(path)[-1] + '.py'
 
 # eegsynth/lib contains shared modules
-sys.path.insert(0, os.path.join(path, '../../lib'))
+sys.path.insert(0, os.path.join(path,'../../lib'))
 import EEGsynth
-import FieldTrip
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--inifile", default=os.path.join(path, os.path.splitext(file)[0] + '.ini'), help="optional name of the configuration file")
@@ -63,24 +62,14 @@ patch = EEGsynth.patch(config, r)
 monitor = EEGsynth.monitor()
 
 # get the options from the configuration file
-debug    = patch.getint('general', 'debug')
-delay    = patch.getfloat('general', 'delay')
-lsl_name = patch.getstring('lsl', 'name')
-lsl_type = patch.getstring('lsl', 'type')
+debug           = patch.getint('general', 'debug')
+delay           = patch.getfloat('general', 'delay')
+lsl_name        = patch.getstring('lsl', 'name')
+lsl_type        = patch.getstring('lsl', 'type')
+lsl_format      = patch.getstring('lsl', 'format')
+output_prefix   = patch.getstring('output', 'prefix')
 
-try:
-    ftc_host = patch.getstring('fieldtrip', 'hostname')
-    ftc_port = patch.getint('fieldtrip', 'port')
-    if debug > 0:
-        print('Trying to connect to buffer on %s:%i ...' % (ftc_host, ftc_port))
-    ft_output = FieldTrip.Client()
-    ft_output.connect(ftc_host, ftc_port)
-    if debug > 0:
-        print("Connected to output FieldTrip buffer")
-except:
-    raise RuntimeError("cannot connect to output FieldTrip buffer")
-
-# first resolve an EEG stream on the lab network
+# first resolve a Marker stream on the lab network
 print("looking for an LSL stream...")
 streams = lsl.resolve_streams()
 selected = []
@@ -89,9 +78,6 @@ for stream in streams:
     inlet           = lsl.StreamInlet(stream)
     name            = inlet.info().name()
     type            = inlet.info().type()
-    channel_count   = inlet.info().channel_count()
-    nominal_srate   = inlet.info().nominal_srate()
-    channel_format  = inlet.info().channel_format()
     source_id       = inlet.info().source_id()
     # determine whether this stream should be further processed
     match = True
@@ -108,16 +94,9 @@ for stream in streams:
     if debug>0:
         print("name", name)
         print("type", type)
-        print("channel_count", channel_count)
-        print("nominal_srate", nominal_srate)
-        print("channel_format", channel_format)
-        print("source_id", source_id)
-    print('-------------------------')
-
+print('-------------------------')
 # create a new inlet from the first (and hopefully only) selected stream
 inlet = lsl.StreamInlet(selected[0])
-channel_count = inlet.info().channel_count()
-nominal_srate = inlet.info().nominal_srate()
 
 # give some feedback
 lsl_name = inlet.info().name()
@@ -125,20 +104,28 @@ lsl_type = inlet.info().type()
 lsl_id   = inlet.info().source_id()
 print('connected to LSL stream %s (type = %s, id = %s)' % (lsl_name, lsl_type, lsl_id))
 
-ft_output.putHeader(channel_count, nominal_srate, FieldTrip.DATATYPE_FLOAT32)
-
-# this is used for feedback
-count = 0
-start = -np.Inf
-
 while True:
     monitor.loop()
 
-    chunk, timestamps = inlet.pull_chunk()
-    if timestamps:
-        dat = np.asarray(chunk, dtype=np.float32)
-        count += dat.shape[0]
-        ft_output.putData(dat)
-        if debug>0 and (time.time()-start)>delay:
-            print("processed %d samples" % count)
-            start = time.time()
+    sample, timestamp = inlet.pull_sample(timeout=delay)
+    if not sample==None:
+
+        if lsl_format=='value':
+            # interpret the LSL marker string as a numerical value
+            try:
+                val = float(sample[0])
+            except ValueError:
+                val = np.NaN
+            # the scale and offset options can be changed on the fly
+            scale = patch.getfloat('lsl', 'scale', default=1./127)
+            offset = patch.getfloat('lsl', 'offset', default=0.)
+            val = EEGsynth.rescale(val, slope=scale, offset=offset)
+            name = '%s.%s.%s' % (output_prefix, lsl_name, lsl_type)
+        else:
+            # use the marker string as the name, and use an arbitrary value
+            name = '%s.%s.%s.%s' % (output_prefix, lsl_name, lsl_type, sample[0])
+            val = 1.
+
+        # send the Redis message
+        print(name, '=', val)
+        patch.setvalue(name, val)

--- a/module/lsl2ft/lsl2ft.ini
+++ b/module/lsl2ft/lsl2ft.ini
@@ -11,6 +11,6 @@ hostname=localhost
 port=6379
 
 [lsl]
-; this can be used to select the desired stream in case there are multiple
+; this can be used to select the desired stream (in case there are multiple)
 name=
 type=EEG

--- a/module/outputlsl/README.md
+++ b/module/outputlsl/README.md
@@ -1,0 +1,15 @@
+# OutputLSL
+
+This module sends triggers and control value changes from Redis to LabStreamingLayer (LSL).
+
+In the EEGsynth we are using two different mechanisms for communication. Continuous control channels are represented in Redis using *set/get*, which allow relatively slowly changing values to be represented persistently. Triggers are represented in Redis using *publish/subscribe*, which allows precise timing of events to be synchronized.
+
+A limitation of the LSL marker format is that it only contain a single string value. Under the `[lsl]` section you can specify by the format whether you want the LSL marker string to represent the Redis name, or the Redis value.
+
+## Triggers
+
+Under the `[trigger]` section you specify the mapping between LSL string markers and Redis messages. The LSL markers are triggered immediately by Redis messages.
+
+## Continuous control channels
+
+Under the `[control]` section you specify the mapping between LSL markers and Redis channels. Upon starting this module, the initial values will be sent as LSL markers. Subsequently, the value of the Redis channels are sampled regularly (given the `delay` parameter) and sent as LSL markers if the value changes.

--- a/module/outputlsl/outputlsl.ini
+++ b/module/outputlsl/outputlsl.ini
@@ -1,0 +1,40 @@
+[general]
+debug=2
+delay=0.05
+
+[redis]
+hostname=localhost
+port=6379
+
+[lsl]
+name=eegsynth
+type=Markers
+; id=123456
+format=string     ; string or value, how to translate from Redis to the LSL marker
+
+[trigger]
+; triggers are sent as LSL event as soon as the value changes
+button=launchcontrol.note        ; this responds to all buttons
+button1=launchcontrol.note073    ; this responds only to a specific button
+button2=launchcontrol.note074
+
+[control]
+; control signals are regularly sampled and sent as LSL event when the value has changed
+slider1=launchcontrol.control077
+slider2=launchcontrol.control078
+
+[scale]
+; the values from Redis are multiplied by this before being sent as LSL marker
+button=1      ; the value represents the integer button number
+button1=127
+button2=127
+slider1=127
+slider2=127
+
+[offset]
+; the offset is added to the Redis value before being sent as LSL marker
+button=0
+button1=0
+button2=0
+slider1=0
+slider2=0

--- a/module/outputlsl/outputlsl.py
+++ b/module/outputlsl/outputlsl.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+
+# This module translates Redis control values and events to LSL string markers.
+#
+# This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
+#
+# Copyright (C) 2019 EEGsynth project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import configparser
+import argparse
+import os
+import random
+import redis
+import string
+import sys
+import threading
+import time
+from pylsl import StreamInfo, StreamOutlet
+
+if hasattr(sys, 'frozen'):
+    path = os.path.split(sys.executable)[0]
+    file = os.path.split(sys.executable)[-1]
+elif sys.argv[0] != '':
+    path = os.path.split(sys.argv[0])[0]
+    file = os.path.split(sys.argv[0])[-1]
+else:
+    path = os.path.abspath('')
+    file = os.path.split(path)[-1] + '.py'
+
+# eegsynth/lib contains shared modules
+sys.path.insert(0, os.path.join(path,'../../lib'))
+import EEGsynth
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-i", "--inifile", default=os.path.join(path, os.path.splitext(file)[0] + '.ini'), help="optional name of the configuration file")
+args = parser.parse_args()
+
+config = configparser.ConfigParser(inline_comment_prefixes=('#', ';'))
+config.read(args.inifile)
+
+try:
+    r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0, charset='utf-8', decode_responses=True)
+    response = r.client_list()
+except redis.ConnectionError:
+    raise RuntimeError("cannot connect to Redis server")
+
+# combine the patching from the configuration file and Redis
+patch = EEGsynth.patch(config, r)
+
+# this can be used to show parameters that have changed
+monitor = EEGsynth.monitor()
+
+# get the options from the configuration file
+debug       = patch.getint('general', 'debug')
+
+# this is to prevent two messages from being sent at the same time
+lock = threading.Lock()
+
+def randomStringDigits(stringLength=6):
+    """Generate a random string of digits """
+    letters = string.digits
+    return ''.join(random.choice(letters) for i in range(stringLength))
+
+lsl_name   = patch.getstring('lsl', 'name', default='eegsynth')
+lsl_type   = patch.getstring('lsl', 'type', default='Markers')
+lsl_id     = patch.getstring('lsl', 'id', default=randomStringDigits())
+lsl_format = patch.getstring('lsl', 'format')
+
+# create an outlet stream
+info = StreamInfo(lsl_name, lsl_type, 1, 0, 'string', lsl_id)
+outlet = StreamOutlet(info)
+
+class TriggerThread(threading.Thread):
+    def __init__(self, trigger, redischannel):
+        threading.Thread.__init__(self)
+        self.redischannel = redischannel
+        self.name = trigger
+        self.running = True
+    def stop(self):
+        self.running = False
+    def run(self):
+        pubsub = r.pubsub()
+        pubsub.subscribe('OUTPUTLSL_UNBLOCK')  # this message unblocks the redis listen command
+        pubsub.subscribe(self.redischannel)  # this message contains the trigger
+        while self.running:
+            for item in pubsub.listen():
+                if not self.running or not item['type'] == 'message':
+                    break
+                if item['channel']==self.redischannel:
+                    if lsl_format=='value':
+                        # map the Redis values to LSL marker values
+                        val = float(item['data'])
+                        # the scale and offset options are channel specific and can be changed on the fly
+                        scale = patch.getfloat('scale', self.name, default=127)
+                        offset = patch.getfloat('offset', self.name, default=0)
+                        val = EEGsynth.rescale(val, slope=scale, offset=offset)
+                        # format the value as a string
+                        marker = '%g' % (val)
+                    else:
+                        marker = self.name
+                    with lock:
+                        if debug>1:
+                            print(marker)
+                        outlet.push_sample([marker])
+
+# create the background threads that deal with the triggers
+trigger = []
+if debug>1:
+    print("Setting up threads for each trigger")
+for item in config.items('trigger'):
+        trigger.append(TriggerThread(item[0], item[1]))
+        if debug>0:
+            print(item[0], item[1], 'OK')
+
+# start the thread for each of the triggers
+for thread in trigger:
+    thread.start()
+
+previous_val = {}
+for item in config.items('control'):
+    name = item[0]
+    previous_val[name] = None
+
+try:
+    while True:
+        monitor.loop()
+        time.sleep(patch.getfloat('general', 'delay'))
+
+        # loop over the control values
+        for item in config.items('control'):
+            name = item[0]
+
+            val = patch.getfloat('control', name)
+            if val is None:
+                continue # it should be skipped when not present in the ini or Redis
+            if val==previous_val[name]:
+                continue # it should be skipped when identical to the previous value
+            previous_val[name] = val
+
+            if lsl_format=='value':
+                # map the Redis values to LSL marker values
+                # the scale and offset options are control channel specific and can be changed on the fly
+                scale = patch.getfloat('scale', name, default=127)
+                offset = patch.getfloat('offset', name, default=0)
+                val = EEGsynth.rescale(val, slope=scale, offset=offset)
+                # format the value as a string
+                marker = '%g' % (val)
+            else:
+                marker = name
+            with lock:
+                if debug>1:
+                    print(marker)
+                outlet.push_sample([marker])
+
+except KeyboardInterrupt:
+    print('Closing threads')
+    for thread in trigger:
+        thread.stop()
+    r.publish('OUTPUTLSL_UNBLOCK', 1)
+    for thread in trigger:
+        thread.join()
+    sys.exit()


### PR DESCRIPTION
Following a discussion with the PROMPT team (including @helenacockx) in which we were discussion the synchronization of various devices (fNIRS, EEG, video, Xsens) using LSL, TTL triggers, and audio, I realized that the EEGsynth already offers most functionality. 

The  only thing that was missing in EEGsynth was an `inputlsl` module, which I just implemented. I also implemented an `outputlsl`, which might come in handy as well.

The improvements in this PR allow an EEGsynth patch to be constructed for a Raspberry Pi that includes
- inputlsl module that receives the start, stop and sync messages 
- outputgpio module for the TTL triggers
- sampler module to play the beeps

The start, stop and sync LSL messages are generated from an experimental control PC that would be running MATLAB, [Psychtoolbox](https://github.com/Psychtoolbox-3/Psychtoolbox-3) and [liblsl-Matlab](https://github.com/labstreaminglayer/liblsl-Matlab).

The patch would run on 4 raspberry pi's: one connected to the Xsens receiver, and three to the video cameras.

  