### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/doc/installation-linux.md
+++ b/doc/installation-linux.md
@@ -140,7 +140,7 @@ sudo pip install pyOSC      # for Python <= 3.5
 sudo pip install pyqtgraph
 sudo pip install matplotlib
 sudo pip install bitalino
-sudo pip install fuzzywuzzy[speedup]
+sudo pip install rapidfuzz
 sudo pip install nilearn
 sudo pip install sklearn
 sudo pip install neurokit

--- a/doc/installation-macos.md
+++ b/doc/installation-macos.md
@@ -98,7 +98,7 @@ pip install pyOSC      # for Python <= 3.5
 pip install pyqtgraph
 pip install matplotlib
 pip install bitalino
-pip install fuzzywuzzy[speedup]
+pip install rapidfuzz
 pip install nilearn
 pip install sklearn
 pip install neurokit

--- a/module/endorphines/endorphines.py
+++ b/module/endorphines/endorphines.py
@@ -22,7 +22,7 @@
 import configparser
 import argparse
 import mido
-from fuzzywuzzy import process
+from rapidfuzz import process
 import os
 import redis
 import sys

--- a/module/generateclock/generateclock.py
+++ b/module/generateclock/generateclock.py
@@ -21,7 +21,7 @@ import configparser
 import argparse
 import math
 import mido
-from fuzzywuzzy import process
+from rapidfuzz import process
 import numpy as np
 import os
 import redis

--- a/module/inputmidi/inputmidi.py
+++ b/module/inputmidi/inputmidi.py
@@ -22,7 +22,7 @@
 import configparser
 import argparse
 import mido
-from fuzzywuzzy import process
+from rapidfuzz import process
 import os
 import redis
 import sys

--- a/module/keyboard/keyboard.py
+++ b/module/keyboard/keyboard.py
@@ -22,7 +22,7 @@
 import configparser
 import argparse
 import mido
-from fuzzywuzzy import process
+from rapidfuzz import process
 import os
 import redis
 import sys

--- a/module/launchcontrol/launchcontrol.py
+++ b/module/launchcontrol/launchcontrol.py
@@ -22,7 +22,7 @@
 import configparser
 import argparse
 import mido
-from fuzzywuzzy import process
+from rapidfuzz import process
 import os
 import redis
 import sys

--- a/module/launchpad/launchpad.py
+++ b/module/launchpad/launchpad.py
@@ -22,7 +22,7 @@
 import configparser
 import argparse
 import mido
-from fuzzywuzzy import process
+from rapidfuzz import process
 import os
 import redis
 import sys

--- a/module/outputcvgate/outputcvgate.py
+++ b/module/outputcvgate/outputcvgate.py
@@ -28,7 +28,7 @@ import threading
 import time
 import serial
 import serial.tools.list_ports
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 if hasattr(sys, 'frozen'):
     path = os.path.split(sys.executable)[0]

--- a/module/outputdmx/outputdmx.py
+++ b/module/outputdmx/outputdmx.py
@@ -27,7 +27,7 @@ import sys
 import time
 import serial
 import serial.tools.list_ports
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 if hasattr(sys, 'frozen'):
     path = os.path.split(sys.executable)[0]

--- a/module/outputmidi/outputmidi.py
+++ b/module/outputmidi/outputmidi.py
@@ -22,7 +22,7 @@
 import configparser
 import argparse
 import mido
-from fuzzywuzzy import process
+from rapidfuzz import process
 import os
 import redis
 import sys

--- a/module/volcabass/volcabass.py
+++ b/module/volcabass/volcabass.py
@@ -22,7 +22,7 @@
 import configparser
 import argparse
 import mido
-from fuzzywuzzy import process
+from rapidfuzz import process
 import os
 import redis
 import sys

--- a/module/volcabeats/volcabeats.py
+++ b/module/volcabeats/volcabeats.py
@@ -22,7 +22,7 @@
 import configparser
 import argparse
 import mido
-from fuzzywuzzy import process
+from rapidfuzz import process
 import os
 import redis
 import sys

--- a/module/volcakeys/volcakeys.py
+++ b/module/volcakeys/volcakeys.py
@@ -22,7 +22,7 @@
 import configparser
 import argparse
 import mido
-from fuzzywuzzy import process
+from rapidfuzz import process
 import os
 import redis
 import sys

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setuptools.setup(
         "bitalino",
         "colorama",
         "configparser",
-        "fuzzywuzzy[speedup]",
+        "rapidfuzz",
         "matplotlib",
         "mido",
         "mido",


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which requires the whole project to be under a GPLv2 License since it is not compatible with GPLv3.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the GPLv3 License
- Is faster than FuzzyWuzzy

One issue with RapidFuzz for this project might be that currently it requires python>=3.5 depending on how long you plan to keep Python2 support