### PR TITLE
implement demodulatetone module

### DIFF
--- a/module/audio2ft/audio2ft.py
+++ b/module/audio2ft/audio2ft.py
@@ -96,7 +96,6 @@ def _start():
     global parser, args, config, r, response, patch, name
     global monitor, debug, device, rate, blocksize, nchans, ft_host, ft_port, ft_output, p, info, i, devinfo, stream, startfeedback, countfeedback
 
-
     # this can be used to show parameters that have changed
     monitor = EEGsynth.monitor(name=name, debug=patch.getint("general", "debug"))
 
@@ -175,9 +174,9 @@ def _loop_once():
     data = np.reshape(np.frombuffer(data, dtype=np.int16), (blocksize, nchans))
     ft_output.putData(data)
 
-    countfeedback += blocksize
-
     monitor.trace("streamed " + str(blocksize) + " samples in " + str((time.time() - start) * 1000) + " ms")
+
+    countfeedback += blocksize
     if countfeedback >= rate:
         # this gets printed approximately once per second
         monitor.debug("streamed " + str(countfeedback) + " samples in " + str((time.time() - startfeedback) * 1000) + " ms")

--- a/module/demodulatetone/README.md
+++ b/module/demodulatetone/README.md
@@ -1,0 +1,5 @@
+# De-modulatetone module
+
+The demodulatetone module takes an audio signal that contains one or multiple amplitude-modulated tones, estimates the modulation amplitude and represents that as a control signal in Redis.
+
+This module complements the modulatetone module.

--- a/module/demodulatetone/__init__.py
+++ b/module/demodulatetone/__init__.py
@@ -1,0 +1,24 @@
+import sys
+import time
+
+from .demodulatetone import _setup, _start, _loop_once, _loop_forever, _stop
+
+class Executable:
+    def __init__(self, args=None):
+        if args!=None:
+            # override the command line arguments
+            sys.argv = [sys.argv[0]] + args
+
+        # the setup MUST pass without errors
+        _setup()
+
+        while True:
+            # keep running until KeyboardInterrupt
+            try:
+                _start()
+                _loop_forever()
+            except RuntimeError:
+                # restart after one second
+                time.sleep(1)
+            except KeyboardInterrupt:
+                raise SystemExit

--- a/module/demodulatetone/demodulatetone.ini
+++ b/module/demodulatetone/demodulatetone.ini
@@ -70,8 +70,8 @@ tone7=demodulate.control083
 tone8=demodulate.control084
 
 [scale]
-amplitude=0.125   ; the total amplitude after summing all tones should never exceed 1.0
-frequency=100     ; allow for a frequency modulation of 100 Hz
+amplitude=8       ; the total amplitude after summing all tones should never exceed 1.0
+frequency=0.01    ; a frequency modulation of 100 Hz maps onto a control signal between 0 and 1
 
 [offset]
 ; assume that the control signals are between 0 and 1

--- a/module/demodulatetone/demodulatetone.ini
+++ b/module/demodulatetone/demodulatetone.ini
@@ -1,0 +1,79 @@
+[general]
+debug=1
+delay=0.05
+
+[redis]
+hostname=localhost
+port=6379
+
+[audio]
+device=4
+rate=44100
+nchans=2          ; 1=mono, 2=stereo, etc.
+modulation=am     ; am or fm
+blocksize=1024
+
+; these are the harmonics of the 1st, 3rd and 5th in the C scale
+frequencies=130.8,164.8,196.0,261.6,329.6,392.0,523.2,659.2,783.9,1046.4,1318.4,1567.8,2092.8,2636.8,3135.7,4185.6,5273.5,6271.3
+
+; evenly spaced frequencies
+; frequencies=500,1000,1500,2000,2500,3000,3500,4000,4500,5000,5500,6000,6500,7000,7500,8000,8500,9000,9500,10000
+
+; these are good frequencies for demodulation with a 512 or 1024 sample FFT window at 44100 Hz
+; frequencies=86.13,258.40,430.66,602.93,775.20,947.46,1119.73,1291.99,1464.26,1636.52,1808.79,1981.05,2153.32,2325.59,2497.85,2670.12,2842.38,3014.65,3186.91,3359.18
+
+; these are good frequencies for demodulation with a 512 or 1024 sample FFT window at 48000 Hz
+; frequencies=93.75,281.25,468.75,656.25,843.75,1031.25,1218.75,1406.25,1593.75,1781.25,1968.75,2156.25,2343.75,2531.25,2718.75,2906.25,3093.75,3281.25,3468.75,3656.25
+
+[left] ; for mono and stereo
+; this example corresponds to the 1st row of knobs of the demodulate XL
+tone1=demodulate.control013
+tone2=demodulate.control014
+tone3=demodulate.control015
+tone4=demodulate.control016
+tone5=demodulate.control017
+tone6=demodulate.control018
+tone7=demodulate.control019
+tone8=demodulate.control020
+
+[right] ; for stereo
+; this example corresponds to the 2nd row of knobs of the demodulate XL
+tone1=demodulate.control029
+tone2=demodulate.control030
+tone3=demodulate.control031
+tone4=demodulate.control032
+tone5=demodulate.control033
+tone6=demodulate.control034
+tone7=demodulate.control035
+tone8=demodulate.control036
+
+[chan3] ; for quadraphonic
+; this example corresponds to the 3rd row of knobs of the demodulate XL
+tone1=demodulate.control049
+tone2=demodulate.control050
+tone3=demodulate.control051
+tone4=demodulate.control052
+tone5=demodulate.control053
+tone6=demodulate.control054
+tone7=demodulate.control055
+tone8=demodulate.control056
+
+[chan4] ; for quadraphonic
+; this example corresponds to the sliders on the demodulate XL
+tone1=demodulate.control077
+tone2=demodulate.control078
+tone3=demodulate.control079
+tone4=demodulate.control080
+tone5=demodulate.control081
+tone6=demodulate.control082
+tone7=demodulate.control083
+tone8=demodulate.control084
+
+[scale]
+amplitude=0.125   ; the total amplitude after summing all tones should never exceed 1.0
+frequency=100     ; allow for a frequency modulation of 100 Hz
+
+[offset]
+; assume that the control signals are between 0 and 1
+amplitude=0
+frequency=0

--- a/module/demodulatetone/demodulatetone.py
+++ b/module/demodulatetone/demodulatetone.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+
+# This module demodulates an audio signal that is comrised of a mixture of modulated tones
+#
+# This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
+#
+# Copyright (C) 2022 EEGsynth project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import configparser
+import argparse
+import numpy as np
+import os
+import redis
+import sys
+import time
+import pyaudio
+
+if hasattr(sys, "frozen"):
+    path = os.path.split(sys.executable)[0]
+    file = os.path.split(sys.executable)[-1]
+    name = os.path.splitext(file)[0]
+elif __name__ == "__main__" and sys.argv[0] != "":
+    path = os.path.split(sys.argv[0])[0]
+    file = os.path.split(sys.argv[0])[-1]
+    name = os.path.splitext(file)[0]
+elif __name__ == "__main__":
+    path = os.path.abspath("")
+    file = os.path.split(path)[-1] + ".py"
+    name = os.path.splitext(file)[0]
+else:
+    path = os.path.split(__file__)[0]
+    file = os.path.split(__file__)[-1]
+    name = os.path.splitext(file)[0]
+
+# eegsynth/lib contains shared modules
+sys.path.insert(0, os.path.join(path, "../../lib"))
+import EEGsynth
+import FieldTrip
+
+
+def _setup():
+    """Initialize the module
+    This adds a set of global variables
+    """
+    global parser, args, config, r, response, patch
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-i",
+        "--inifile",
+        default=os.path.join(path, name + ".ini"),
+        help="name of the configuration file",
+    )
+    args = parser.parse_args()
+
+    config = configparser.ConfigParser(inline_comment_prefixes=("#", ";"))
+    config.read(args.inifile)
+
+    try:
+        r = redis.StrictRedis(
+            host=config.get("redis", "hostname"),
+            port=config.getint("redis", "port"),
+            db=0,
+            charset="utf-8",
+            decode_responses=True,
+        )
+        response = r.client_list()
+    except redis.ConnectionError:
+        raise RuntimeError("cannot connect to Redis server")
+
+    # combine the patching from the configuration file and Redis
+    patch = EEGsynth.patch(config, r)
+
+    # there should not be any local variables in this function, they should all be global
+    if len(locals()):
+        print("LOCALS: " + ", ".join(locals().keys()))
+
+
+def _start():
+    """Start the module
+    This uses the global variables from setup and adds a set of global variables
+    """
+    global parser, args, config, r, response, patch, name
+    global monitor, debug, device, rate, blocksize, nchans, frequencies, ntones, key, p, info, i, devinfo, stream, startfeedback, countfeedback, offset
+
+    # this can be used to show parameters that have changed
+    monitor = EEGsynth.monitor(name=name, debug=patch.getint("general", "debug"))
+
+    # get the options from the configuration file
+    debug = patch.getint("general", "debug")
+    device = patch.getint("audio", "device")
+    rate = patch.getint("audio", "rate", default=44100)
+    nchans = patch.getint("audio", "nchans", default=2)
+    blocksize = patch.getint("audio", "blocksize", default=1024)
+
+    modulation = patch.getstring('audio', 'modulation', default='am')
+    frequencies = patch.getfloat('audio', 'frequencies', multiple=True)
+
+    ntones = len(frequencies)
+    offset = np.zeros((ntones, ), dtype=np.float32)
+
+    monitor.info("rate       = %g" % rate)
+    monitor.info("nchans     = %g" % nchans)
+    monitor.info("blocksize  = %g" % blocksize)
+    monitor.info("modulation = " + modulation)
+
+    channame = ['left', 'right', 'chan3', 'chan4', 'chan5', 'chan6', 'chan7', 'chan8']
+    key = []
+    for chan in range(0, nchans):
+        key.append([])
+        for tone in range(0, ntones):
+            tonestr = "tone%d" % (tone + 1)
+            if patch.hasitem(channame[chan], tonestr):
+                redischannel = patch.getstring(channame[chan], tonestr)
+                key[chan].append(redischannel)
+                monitor.info("configured " + channame[chan] + " " + tonestr + " as " + redischannel)
+            else:
+                key[chan].append(None)
+                monitor.info("not configured " + channame[chan] + " " + tonestr)
+                
+    p = pyaudio.PyAudio()
+
+    monitor.info("------------------------------------------------------------------")
+    info = p.get_host_api_info_by_index(0)
+    monitor.info(info)
+    monitor.info("------------------------------------------------------------------")
+    for i in range(info.get("deviceCount")):
+        if p.get_device_info_by_host_api_device_index(0, i).get("maxInputChannels") > 0:
+            monitor.info("Input  Device id " + str(i) + " - " + p.get_device_info_by_host_api_device_index(0, i).get("name"))
+        if (p.get_device_info_by_host_api_device_index(0, i).get("maxOutputChannels") > 0):
+            monitor.info("Output Device id " + str(i) + " - " + p.get_device_info_by_host_api_device_index(0, i).get("name"))
+    monitor.info("------------------------------------------------------------------")
+    devinfo = p.get_device_info_by_index(device)
+    monitor.info("Selected device is " + devinfo["name"])
+    monitor.info(devinfo)
+    monitor.info("------------------------------------------------------------------")
+
+    stream = p.open(
+        format=pyaudio.paFloat32,
+        channels=nchans,
+        rate=rate,
+        input=True,
+        input_device_index=device,
+        frames_per_buffer=blocksize,
+    )
+
+    startfeedback = time.time()
+    countfeedback = 0
+    offset = 0.
+
+    # there should not be any local variables in this function, they should all be global
+    if len(locals()):
+        print("LOCALS: " + ", ".join(locals().keys()))
+
+
+def _loop_once():
+    """Run the main loop once
+    This uses the global variables from setup and start, and adds a set of global variables
+    """
+    global parser, args, config, r, response, patch
+    global rate, nchans, blocksize, frequencies, ntones, offset, startfeedback, countfeedback
+    global start, data, chan, timeaxis, tone, phase, value, Fsin, Fcos, val
+
+    # measure the time that it takes
+    start = time.time()
+
+    # read a block of data from the audio device and convert raw buffer to numpy array
+    data = stream.read(blocksize)
+    data = np.reshape(np.frombuffer(data, dtype=np.float32), (blocksize, nchans))
+
+    timeaxis = np.arange(0, blocksize) / rate + offset
+    offset += blocksize / rate
+
+    for chan in range(0, nchans):
+        for tone in range(0, ntones):
+            if not key[chan][tone] == None:
+                phase = 2.0 * np.pi * frequencies[tone] * timeaxis
+                Fsin = np.dot(data[:, chan], np.sin(phase))/blocksize
+                Fcos = np.dot(data[:, chan], np.cos(phase))/blocksize
+                val = Fsin*Fsin + Fcos*Fsin
+                patch.setvalue(key[chan][tone], val)
+                monitor.update(key[chan][tone], val)
+
+    monitor.trace("streamed " + str(blocksize) + " samples in " + str((time.time() - start) * 1000) + " ms")
+
+    countfeedback += blocksize
+    if countfeedback >= rate:
+        # this gets printed approximately once per second
+        monitor.debug("streamed " + str(countfeedback) + " samples in " + str((time.time() - startfeedback) * 1000) + " ms")
+        startfeedback = time.time()
+        countfeedback = 0
+
+    # there should not be any local variables in this function, they should all be global
+    if len(locals()):
+        print("LOCALS: " + ", ".join(locals().keys()))
+
+
+def _loop_forever():
+    """Run the main loop forever
+    """
+    global monitor
+    while True:
+        monitor.loop()
+        _loop_once()
+
+
+def _stop():
+    """Stop and clean up on SystemExit, KeyboardInterrupt
+    """
+    global stream, p
+    stream.stop_stream()
+    stream.close()
+    p.terminate()
+    sys.exit()
+
+
+if __name__ == "__main__":
+    _setup()
+    _start()
+    try:
+        _loop_forever()
+    except (SystemExit, KeyboardInterrupt, RuntimeError):
+        _stop()

--- a/module/modulatetone/modulatetone.ini
+++ b/module/modulatetone/modulatetone.ini
@@ -9,8 +9,8 @@ port=6379
 [audio]
 device=1
 rate=44100
-mode=stereo       ; mono, stereo, or quad
-modulation=am     ; fm or am
+nchans=2          ; 1=mono, 2=stereo, etc.
+modulation=am     ; am or fm
 
 ; these are the harmonics of the 1st, 3rd and 5th in the C scale
 frequencies=130.8,164.8,196.0,261.6,329.6,392.0,523.2,659.2,783.9,1046.4,1318.4,1567.8,2092.8,2636.8,3135.7,4185.6,5273.5,6271.3


### PR DESCRIPTION
for now it only does AM demodulation, FM is something that might be implemented later. I have not been able to test it fully, since pyaudio somehow does not work on my recently upgraded macOS Monterey (neither for audio2ft, neither for a small example script).  

Another idea not yet included in the current implementation is to use one of the tones as a reference, and use that to scale all others. The input audio is not assumed to have a certain level (depends on the output volume of the other computer), scaling to a non-modulated reference makes it possible to code values between 0 and 1.  
 