### PR TITLE
implemented FieldTrip buffer module for EEGsynth in pure Python

### DIFF
--- a/bin/eegsynth.py
+++ b/bin/eegsynth.py
@@ -7,7 +7,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2019-2020 EEGsynth project
+# Copyright (C) 2019-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -42,7 +42,7 @@ git clone https://github.com/eegsynth/eegsynth.git
 
 ## Install the binary dependencies on FieldTrip
 
-For interfacing with the EEG amplifiers we use the FieldTrip buffer and the associated amplifier-specific applications. Each of them is a small executable that is implemented in C and already compiled. These executables are different for each computing platform (i386, ARM, etc.) and for each operating system. In the eegsynth/bin directory you can find a small installer script that helps you to select and download the correct ones.
+For interfacing between specific EEG amplifiers and the FieldTrip buffer we sometimes use a small executable that is implemented in C and already compiled. These executables are different for each computing platform (i386, ARM, etc.) and for each operating system. In the `eegsynth/bin` directory you can find a small installer script that helps you to select and download the correct ones.
 
 On Linux and macOS you can use the following to install the buffer and the openbci2ft executables.
 
@@ -51,7 +51,7 @@ cd eegsynth/bin
 install.sh
 ```
 
-On Windows you have to download buffer.exe and openbci2ft.exe by hand from the [fieldtrip repository](https://github.com/fieldtrip/fieldtrip/tree/master/realtime/bin/win64) and copy them to the `bin` directory.
+On Windows you have to download them by hand from the [fieldtrip repository](https://github.com/fieldtrip/fieldtrip/tree/master/realtime/bin/win64) and copy them to the `bin` directory.
 
 ## Quick test
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -14,7 +14,7 @@ We recommend that you use [Anaconda](https://www.anaconda.com) to install Python
 conda create -n eegsynth python=3.7 anaconda
 conda activate eegsynth
 
-conda install redis
+conda install redis  # note that this is not yet sufficient for windows
 conda install redis-py
 conda install numpy
 conda install scipy

--- a/doc/scripts.md
+++ b/doc/scripts.md
@@ -29,7 +29,7 @@ Each script is prefaced with a commented text explaining it's functionality, as 
 #
 # This software is part of the EEGsynth project, see https://github.com/eegsynth/eegsynth
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/doc/tutorial1.md
+++ b/doc/tutorial1.md
@@ -11,8 +11,8 @@ The EEGsynth uses the FieldTrip buffer to communicate data between modules. It i
 
 1.  Navigate to the buffer module directory _/eegsynth/module/buffer_
 2.  Copy the _buffer.ini_ to your own ini directory (e.g. to _/eegsynth/inifiles_, which would be in _../../inifiles_ relative to the buffer module directory)
-3.  Start up the buffer module, using your own ini file: _./buffer.sh -i ../../inifiles/buffer.ini_. Note here that the buffer module is one of the few modules that are an executable written in C, run from a bash script rather than Python. However, it does function exactly the same concerning the user-specific ini files.
-4.  If the buffer module is running correctly, it does not print any feedback in the terminal. So no news is good news!
+3.  Edit your _buffer.ini_ to specify the TCP ports on which you want the buffer server to listen. Note that the defaults are probably fine.
+4.  Now start up the buffer module, using your own .ini file: `python buffer.py -i ../../inifiles/playbacksignal.ini`
 
 # Writing pre-recorded data from HDD to the buffer
 
@@ -21,12 +21,9 @@ We will then write some prerecorded data into the buffer as if it was being reco
 1.  Download some example data in .edf format. For example, from our [data directory on Google Drive](https://drive.google.com/drive/folders/0B10S8PeNnxw1ZnZPbUh0RWk0cjA). Or use the data you recorded in the [recording tutorial](https://braincontrolclub.miraheze.org/wiki/Recording_tutorial "Recording tutorial").
 2.  Place the .edf file in a directory, e.g. in _/eegsynth/datafiles_
 3.  Navigate to the playback module directory _/eegsynth/module/playbacksignal_
-4.  Copy the _playbacksignal.ini_ to your own ini directory (e.g. to _/eegsynth/inifiles_, which would be in
-    _../../inifiles_ relative to the buffer module directory)
-5.  Edit your _playbacksignal.ini_ to direct the playback module to the right edf data file, e.g. under `[playback]`
-    edit: `file = ../../datafiles/testBipolar20170827-0.edf`
-6.  Edit the two _playbacksignal.ini_ options for playback and rewind so that it will play back automatically
-    (and not rewind): `play=1` and `rewind=0`
+4.  Copy the _playbacksignal.ini_ to your own ini directory (e.g. to _/eegsynth/inifiles_, which would be in _../../inifiles_ relative to the buffer module directory)
+5.  Edit your _playbacksignal.ini_ to direct the playback module to the right edf data file, e.g. under `[playback]` edit: `file = ../../datafiles/testBipolar20170827-0.edf`
+6.  Edit the two _playbacksignal.ini_ options for playback and rewind so that it will play back automatically (and not rewind): `play=1` and `rewind=0`
 7.  Make note that you can comment out (hide from the module) lines of text by adding a semicolon (;) at the beginning of the line
 8.  Now start up the playback module, using your own .ini file: `python playbacksignal.py -i ../../inifiles/playbacksignal.ini`
 9.  If all is well, the module will print out the samples that it is 'playing back'. This is that data that is successively entered into the buffer as if was just recorded

--- a/lib/EEGsynth.py
+++ b/lib/EEGsynth.py
@@ -135,7 +135,7 @@ class monitor():
 ##############################################################################
 # %s is part of EEGsynth, see <http://www.eegsynth.org>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/FieldTrip.py
+++ b/lib/FieldTrip.py
@@ -327,28 +327,27 @@ class Client:
         (nchans, nsamp, nevt, fsamp, dtype, bfsiz) = struct.unpack('IIIfII', payload[0:24])
 
         H = Header()
-        nChannels = nchans
-        nSamples = nsamp
-        nEvents = nevt
-        fSample = fsamp
-        dataType = dtype
+        H.nChannels = nchans
+        H.nSamples = nsamp
+        H.nEvents = nevt
+        H.fSample = fsamp
+        H.dataType = dtype
 
         if bfsiz > 0:
             offset = 24
             while offset + 8 < bufsize:
-                (chunk_type, chunk_len) = struct.unpack(
-                    'II', payload[offset:offset + 8])
+                (chunk_type, chunk_len) = struct.unpack('II', payload[offset:offset + 8])
                 offset += 8
                 if offset + chunk_len > bufsize:
                     break
-                chunks[chunk_type] = payload[offset:offset + chunk_len]
+                H.chunks[chunk_type] = payload[offset:offset + chunk_len]
                 offset += chunk_len
 
-            if CHUNK_CHANNEL_NAMES in chunks:
-                L = chunks[CHUNK_CHANNEL_NAMES].split(b'\0')
+            if CHUNK_CHANNEL_NAMES in H.chunks:
+                L = H.chunks[CHUNK_CHANNEL_NAMES].split(b'\0')
                 numLab = len(L)
-                if numLab >= nChannels:
-                    labels = [x.decode('utf-8') for x in L[0:nChannels]]
+                if numLab >= H.nChannels:
+                    H.labels = [x.decode('utf-8') for x in L[0:H.nChannels]]
 
         return H
 
@@ -584,7 +583,7 @@ class Server():
         self.sel = selectors.DefaultSelector()
         self.sel.register(lsock, selectors.EVENT_READ, data = None)
 
-    
+
     def disconnect(self):
         self.sel.close()
         self.sel = None

--- a/lib/FieldTrip.py
+++ b/lib/FieldTrip.py
@@ -1,5 +1,5 @@
 """
-FieldTrip buffer (V1) client in pure Python
+FieldTrip buffer (V1) client and server in pure Python
 
 (C) 2010      S. Klanke
 (C) 2010-2022 R. Oostenveld
@@ -558,7 +558,6 @@ class Client:
 ##########################################################################################
 
 class Server():
-
     """Class for a FieldTrip buffer server."""
 
     def __init__(self):
@@ -574,6 +573,7 @@ class Server():
     def connect(self, hostname='localhost', port=1972):
         if self.isConnected:
             raise RuntimeError('Already connected.')
+
         lsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         lsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         lsock.bind((hostname, port))
@@ -588,6 +588,7 @@ class Server():
     def disconnect(self):
         if not self.isConnected:
             raise RuntimeError('Not connected.')
+
         self.sel.close()
         self.sel = None
         self.isConnected = False
@@ -596,6 +597,7 @@ class Server():
     def accept_wrapper(self, sock):
         if not self.isConnected:
             raise RuntimeError('Not connected.')
+
         conn, addr = sock.accept()  # Should be ready to read
         print(f'Accepted connection from {addr}')
         conn.setblocking(False)
@@ -745,11 +747,12 @@ class Server():
                 self.sel.unregister(sock)
                 sock.close()
 
+
     def loop(self):
         if not self.isConnected:
             raise IOError('Not connected.')
             
-        # use the timeout to return control to the main loop once every second
+        # the timeout is used to return control to the main loop once in a while
         events = self.sel.select(timeout = self.timeout)
         for key, mask in events:
             if key.data is None:

--- a/lib/FieldTrip_test_client.py
+++ b/lib/FieldTrip_test_client.py
@@ -1,0 +1,23 @@
+import FieldTrip
+import numpy as np
+
+client = FieldTrip.Client()
+
+port = 1972
+while not client.isConnected and port<2000:
+    try:
+        client.connect('localhost', port=port)
+        print('Connected on', ('localhost', port))
+    except:
+        port += 1
+
+H = client.getHeader()
+print(H)
+
+# read one second of data
+begsample = 0
+endsample = int(H.fSample-1)
+
+D = client.getData(index=(begsample, endsample))
+print(D)
+print(len(D))

--- a/lib/FieldTrip_test_server.py
+++ b/lib/FieldTrip_test_server.py
@@ -1,8 +1,14 @@
 import FieldTrip
-import time
 
 server = FieldTrip.Server()
-server.connect(port=1972)
+
+port = 1972
+while not server.isConnected and port<2000:
+    try:
+        server.connect(port=port)
+    except:
+        port += 1
+
 try:
     while True:
         server.loop()

--- a/lib/FieldTrip_test_server.py
+++ b/lib/FieldTrip_test_server.py
@@ -1,0 +1,12 @@
+import FieldTrip
+import time
+
+server = FieldTrip.Server()
+server.connect(port=1972)
+try:
+    while True:
+        server.loop()
+except KeyboardInterrupt:
+    print('stopping')
+finally:
+    server.disconnect()

--- a/lib/RingBuffer.py
+++ b/lib/RingBuffer.py
@@ -1,0 +1,63 @@
+class RingBuffer:
+    """
+    Class that implements a ring or cyclic buffer that automatically wraps around.
+    It works with bytes and has the methods append() and read().
+    """
+
+    def __init__(self, length):
+        self.buffer = bytearray(length)
+        self.length = length
+        self.count = 0
+
+    def append(self, data):
+        """
+        append - add bytes to the end of the ringbuffer.
+        """
+        if len(data)>self.length:
+            # remove the part of the data that does not fit anyway
+            self.count += int(len(data)/self.length)*self.length
+            data = data[-self.length:]
+
+        begbyte = self.count % self.length
+        endbyte = (self.count + len(data) - 1) % self.length + 1
+
+        if endbyte<begbyte:
+            # insert the first section towards the end
+            numbytes = self.length - begbyte + 1
+            self.buffer[begbyte:self.length] = data[0:numbytes]
+            # insert the second section at the start
+            self.buffer[0:endbyte] = data[numbytes:]
+        elif endbyte>begbyte:
+            # simply insert the data
+            self.buffer[begbyte:endbyte] = data
+        else:
+            # there is nothing to insert
+            pass
+        self.count += len(data)
+
+    def read(self, begbyte, endbyte):
+        """
+        read() - read bytes from a specific location in the ringbuffer.
+        """
+        if self.count>self.length:
+            begavailable = self.count - self.length
+        else:
+            begavailable = 0
+        endavailable = self.count
+
+        if begbyte<begavailable:
+            raise RuntimeError('Cannot read before the start of the available data.')
+        elif endbyte>endavailable or begbyte>endavailable-1:
+            raise RuntimeError('Cannot read past the end of the available data.')
+        elif endbyte<begbyte:
+            raise RuntimeError('Invalid selection.')
+        begbyte = begbyte % self.length
+        endbyte = (endbyte-1) % self.length + 1
+        try:
+            if endbyte<=begbyte:
+                data = self.buffer[begbyte:] + self.buffer[0:endbyte]
+            else:
+                data = self.buffer[begbyte:endbyte]
+        except:
+            data = bytes(numbytes)
+        return data

--- a/lib/RingBuffer.py
+++ b/lib/RingBuffer.py
@@ -11,7 +11,7 @@ class RingBuffer:
 
     def append(self, data):
         """
-        append - add bytes to the end of the ringbuffer.
+        append(bytes) - add bytes to the end of the buffer.
         """
         if len(data)>self.length:
             # remove the part of the data that does not fit anyway
@@ -37,14 +37,14 @@ class RingBuffer:
 
     def read(self, begbyte, endbyte):
         """
-        read() - read bytes from a specific location in the ringbuffer.
+        read(begbyte, endbyte) - read bytes from a specific location in the buffer.
         """
         if self.count>self.length:
             begavailable = self.count - self.length
         else:
             begavailable = 0
         endavailable = self.count
-
+        
         if begbyte<begavailable:
             raise RuntimeError('Cannot read before the start of the available data.')
         elif endbyte>endavailable or begbyte>endavailable-1:
@@ -52,12 +52,10 @@ class RingBuffer:
         elif endbyte<begbyte:
             raise RuntimeError('Invalid selection.')
         begbyte = begbyte % self.length
-        endbyte = (endbyte-1) % self.length + 1
-        try:
-            if endbyte<=begbyte:
-                data = self.buffer[begbyte:] + self.buffer[0:endbyte]
-            else:
-                data = self.buffer[begbyte:endbyte]
-        except:
-            data = bytes(numbytes)
+        endbyte = (endbyte - 1) % self.length + 1
+    
+        if endbyte<=begbyte:
+            data = self.buffer[begbyte:] + self.buffer[0:endbyte]
+        else:
+            data = self.buffer[begbyte:endbyte]
         return data

--- a/module/accelerometer/accelerometer.py
+++ b/module/accelerometer/accelerometer.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/audio2ft/audio2ft.py
+++ b/module/audio2ft/audio2ft.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/biochill/biochill.py
+++ b/module/biochill/biochill.py
@@ -2,7 +2,7 @@
 
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/bitalino2ft/bitalino2ft.py
+++ b/module/bitalino2ft/bitalino2ft.py
@@ -4,7 +4,7 @@
 #
 # This module is part of the EEGsynth project (https://github.com/eegsynth/eegsynth)
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/buffer/__init__.py
+++ b/module/buffer/__init__.py
@@ -1,0 +1,24 @@
+import sys
+import time
+
+from .buffer import _setup, _start, _loop_once, _loop_forever, _stop
+
+class Executable:
+    def __init__(self, args=None):
+        if args!=None:
+            # override the command line arguments
+            sys.argv = [sys.argv[0]] + args
+
+        # the setup MUST pass without errors
+        _setup()
+
+        while True:
+            # keep running until KeyboardInterrupt
+            try:
+                _start()
+                _loop_forever()
+            except RuntimeError:
+                # restart after one second
+                time.sleep(1)
+            except KeyboardInterrupt:
+                raise SystemExit

--- a/module/buffer/buffer.ini
+++ b/module/buffer/buffer.ini
@@ -1,10 +1,10 @@
 [general]
 debug=2
+delay=0.010
 
 [redis]
 hostname=localhost
 port=6379
 
 [fieldtrip]
-hostname=localhost
 port=1972,1973,1974

--- a/module/buffer/buffer.ini
+++ b/module/buffer/buffer.ini
@@ -1,2 +1,10 @@
+[general]
+debug=2
+
+[redis]
+hostname=localhost
+port=6379
+
 [fieldtrip]
+hostname=localhost
 port=1972,1973,1974

--- a/module/buffer/buffer.py
+++ b/module/buffer/buffer.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+# Buffer starts a FieldTrip buffer server
+#
+# This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
+#
+# Copyright (C) 2022 EEGsynth project
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import configparser
+import argparse
+import os
+import redis
+import sys
+import time
+import threading
+
+if hasattr(sys, 'frozen'):
+    path = os.path.split(sys.executable)[0]
+    file = os.path.split(sys.executable)[-1]
+    name = os.path.splitext(file)[0]
+elif __name__ == '__main__' and sys.argv[0] != '':
+    path = os.path.split(sys.argv[0])[0]
+    file = os.path.split(sys.argv[0])[-1]
+    name = os.path.splitext(file)[0]
+elif __name__ == '__main__':
+    path = os.path.abspath('')
+    file = os.path.split(path)[-1] + '.py'
+    name = os.path.splitext(file)[0]
+else:
+    path = os.path.split(__file__)[0]
+    file = os.path.split(__file__)[-1]
+    name = os.path.splitext(file)[0]
+
+# eegsynth/lib contains shared modules
+sys.path.insert(0, os.path.join(path, '../../lib'))
+import EEGsynth
+import FieldTrip
+
+
+def _setup():
+    '''Initialize the module
+    This adds a set of global variables
+    '''
+    global parser, args, config, r, response, patch
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--inifile", default=os.path.join(path, name + '.ini'), help="name of the configuration file")
+    args = parser.parse_args()
+
+    config = configparser.ConfigParser(inline_comment_prefixes=('#', ';'))
+    config.read(args.inifile)
+
+    try:
+        r = redis.StrictRedis(host=config.get('redis', 'hostname'), port=config.getint('redis', 'port'), db=0, charset='utf-8', decode_responses=True)
+        response = r.client_list()
+    except redis.ConnectionError:
+        raise RuntimeError("cannot connect to Redis server")
+
+    # combine the patching from the configuration file and Redis
+    patch = EEGsynth.patch(config, r)
+
+
+def _start():
+    '''Start the module
+    This uses the global variables from setup and adds a set of global variables
+    '''
+    global parser, args, config, r, response, patch
+    global monitor, debug, delay, port, server
+
+    # this can be used to show parameters that have changed
+    monitor = EEGsynth.monitor(name=name, debug=patch.getint('general', 'debug'))
+
+    # get the options from the configuration file
+    debug = patch.getint('general', 'debug')
+    delay = patch.getfloat('general', 'delay', default=0.010)
+    port = patch.getint('fieldtrip', 'port', multiple=True)
+    
+    server = []
+    for p in port:
+        monitor.info("starting server on %d" % p)
+        s = FieldTrip.Server()
+        s.connect(hostname='localhost', port=p)
+        s.timeout = 0 # the server main loop should not wait, as it would block the other instances
+        server.append(s);
+    del p, s
+        
+
+def _loop_once():
+    '''Run the main loop once
+    '''
+    global server
+    for s in server:
+        s.loop() # deal with new connections and incoming requests
+
+
+def _loop_forever():
+    '''Run the main loop forever
+    '''
+    global delay
+    while True:
+        monitor.loop()
+        _loop_once()
+        time.sleep(delay)
+
+
+def _stop():
+    '''Stop and clean up on SystemExit, KeyboardInterrupt
+    '''
+    global monitor, server
+    for s in server:
+        s.disconnect()
+    sys.exit()
+
+
+if __name__ == '__main__':
+    _setup()
+    _start()
+    try:
+        _loop_forever()
+    except (SystemExit, KeyboardInterrupt, RuntimeError):
+        _stop()

--- a/module/clockdivider/clockdivider.py
+++ b/module/clockdivider/clockdivider.py
@@ -2,7 +2,7 @@
 
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/clockmultiplier/clockmultiplier.py
+++ b/module/clockmultiplier/clockmultiplier.py
@@ -2,7 +2,7 @@
 
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/cogito/cogito.py
+++ b/module/cogito/cogito.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/complexity/complexity.py
+++ b/module/complexity/complexity.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/compressor/compressor.py
+++ b/module/compressor/compressor.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/endorphines/endorphines.py
+++ b/module/endorphines/endorphines.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/generateclock/generateclock.py
+++ b/module/generateclock/generateclock.py
@@ -2,7 +2,7 @@
 
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/generatecontrol/generatecontrol.py
+++ b/module/generatecontrol/generatecontrol.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/generatesignal/generatesignal.py
+++ b/module/generatesignal/generatesignal.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/geomixer/geomixer.py
+++ b/module/geomixer/geomixer.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/heartrate/heartrate.py
+++ b/module/heartrate/heartrate.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/historycontrol/historycontrol.py
+++ b/module/historycontrol/historycontrol.py
@@ -2,7 +2,7 @@
 
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/historysignal/historysignal.py
+++ b/module/historysignal/historysignal.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/inputmidi/inputmidi.py
+++ b/module/inputmidi/inputmidi.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/inputosc/inputosc.py
+++ b/module/inputosc/inputosc.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/keyboard/keyboard.py
+++ b/module/keyboard/keyboard.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/launchcontrol/launchcontrol.py
+++ b/module/launchcontrol/launchcontrol.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/launchpad/launchpad.py
+++ b/module/launchpad/launchpad.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/lsl2ft/lsl2ft.py
+++ b/module/lsl2ft/lsl2ft.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2019-2020 EEGsynth project
+# Copyright (C) 2019-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/outputartnet/outputartnet.py
+++ b/module/outputartnet/outputartnet.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/outputaudio/outputaudio.py
+++ b/module/outputaudio/outputaudio.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/outputcvgate/outputcvgate.py
+++ b/module/outputcvgate/outputcvgate.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/outputdmx/outputdmx.py
+++ b/module/outputdmx/outputdmx.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/outputgpio/outputgpio.py
+++ b/module/outputgpio/outputgpio.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/outputmidi/outputmidi.py
+++ b/module/outputmidi/outputmidi.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/outputosc/outputosc.py
+++ b/module/outputosc/outputosc.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/playbackcontrol/playbackcontrol.py
+++ b/module/playbackcontrol/playbackcontrol.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/playbacksignal/playbacksignal.py
+++ b/module/playbacksignal/playbacksignal.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/plotcontrol/plotcontrol.py
+++ b/module/plotcontrol/plotcontrol.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/plotsignal/plotsignal.py
+++ b/module/plotsignal/plotsignal.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/plotspectral/plotspectral.py
+++ b/module/plotspectral/plotspectral.py
@@ -5,7 +5,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/plottrigger/plottrigger.py
+++ b/module/plottrigger/plottrigger.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/polarbelt/polarbelt.py
+++ b/module/polarbelt/polarbelt.py
@@ -2,7 +2,7 @@
 
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/postprocessing/postprocessing.py
+++ b/module/postprocessing/postprocessing.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/preprocessing/preprocessing.py
+++ b/module/preprocessing/preprocessing.py
@@ -5,7 +5,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/processtrigger/processtrigger.py
+++ b/module/processtrigger/processtrigger.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/quantizer/quantizer.py
+++ b/module/quantizer/quantizer.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/recordcontrol/recordcontrol.py
+++ b/module/recordcontrol/recordcontrol.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/recordsignal/recordsignal.py
+++ b/module/recordsignal/recordsignal.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/recordtrigger/recordtrigger.py
+++ b/module/recordtrigger/recordtrigger.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/rms/rms.py
+++ b/module/rms/rms.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/sampler/sampler.py
+++ b/module/sampler/sampler.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/sequencer/sequencer.py
+++ b/module/sequencer/sequencer.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/sonification/sonification.py
+++ b/module/sonification/sonification.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2018-2020 EEGsynth project
+# Copyright (C) 2018-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/spectral/spectral.py
+++ b/module/spectral/spectral.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/synthesizer/synthesizer.py
+++ b/module/synthesizer/synthesizer.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/threshold/threshold.py
+++ b/module/threshold/threshold.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/volcabass/volcabass.py
+++ b/module/volcabass/volcabass.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/volcabeats/volcabeats.py
+++ b/module/volcabeats/volcabeats.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/module/volcakeys/volcakeys.py
+++ b/module/volcakeys/volcakeys.py
@@ -4,7 +4,7 @@
 #
 # This software is part of the EEGsynth project, see <https://github.com/eegsynth/eegsynth>.
 #
-# Copyright (C) 2017-2020 EEGsynth project
+# Copyright (C) 2017-2022 EEGsynth project
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setuptools.setup(
     packages=["eegsynth"] + ["eegsynth." + s for s in setuptools.find_packages(".")],
     install_requires=[
         "bitalino",
+        "bringbuf",
         "colorama",
         "configparser",
         "fuzzywuzzy[speedup]",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ long_description = long_description.replace(
 
 setuptools.setup(
     name="eegsynth",
-    version="0.4.2",
+    version="0.5.0",
     description="Converting real-time EEG into sounds, music and visual effects",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setuptools.setup(
     packages=["eegsynth"] + ["eegsynth." + s for s in setuptools.find_packages(".")],
     install_requires=[
         "bitalino",
-        "bringbuf",
         "colorama",
         "configparser",
         "fuzzywuzzy[speedup]",


### PR DESCRIPTION
When installing the EEGsynth on a new windows computer, I once again realized that EEGsynth is mostly Python, but that it has a dependency on the Redis server *and* on the binary executable for the FieldTrip buffer. There is no plan to remove the dependency on Redis, but not having to download the right `buffer.exe` from [FieldTrip](https://github.com/fieldtrip/fieldtrip/tree/master/realtime/bin) will make the installation quite a bit simpler. Hence I have tried to make a pure Python implementation of the FieldTrip buffer. 

Most of the code is in the `lib/FieldTrip.py` module in a new `Server()` class. A little bit is in the `lib/RingBuffer.py` modules, which implements the in-memory ring buffer. For EEGsynth I made a new `buffer.py` module that is started just like all other modules. This also means that the buffer can now be started with the `eegsynth` command line utility. It supports starting multiple buffers at once and the default is to start three of them on 1972, 1973, and 1974. 

At the moment most - but not all -  functionality is implemented in the pure Python buffer. Events are not supported, nor are the `PUT` requests without response. Different CPU endianness between server and client is also not considered in the code yet. 
