### PR TITLE
FIX #395 - implement reading of strings from redis

### DIFF
--- a/lib/EEGsynth.py
+++ b/lib/EEGsynth.py
@@ -378,6 +378,9 @@ class patch():
         # get all items from the ini file, there might be one or multiple
         try:
             val = self.config.get(section, item)
+            if self.redis.exists(val):
+                # the ini file points to a Redis key, which contains the actual value
+                val = self.redis.get(val)
         except:
             val = default
 

--- a/module/inputcontrol/inputcontrol.py
+++ b/module/inputcontrol/inputcontrol.py
@@ -219,8 +219,11 @@ class Window(QWidget):
         if target.type == 'slider' or target.type == 'dial':
             val = target.value()
         elif target.type == 'text':
-            val = float(target.text())  # convert the string into a scalar
-            target.setText('%g' % val)  # ensure that the displayed value is consistent
+            try:
+                val = float(target.text())  # convert the string into a scalar
+                target.setText('%g' % val)  # ensure that the displayed value is consistent
+            except:
+                val = target.text()
         elif target.type == 'slap':
             target.value = (target.value + 1) % 2
             val = target.value * 127 / 1


### PR DESCRIPTION
- if an ini key points to a redis channel, that value is now returned with patch.getstring()
- updated in[putcontrol so that a string is also allowed in a text entry field (although the default is still to try whether it is a float)