### PR TITLE
update from fixed pyqtgraph 0.12 to the most recent (0.13.3) version

### DIFF
--- a/doc/installation-linux.md
+++ b/doc/installation-linux.md
@@ -162,7 +162,7 @@ sudo apt-get install python-scipy
 
 ### Install graphics
 
-The plotsignal and plotcontrol modules are implemented with pyqtgraph, which uses either PyQt4, PyQt5 or PySide. This can be installed with
+The graphical user interfaces of `plotsignal`, `plotcontrol`, `plotspectral` and `plottrigger` are implemented with pyqtgraph, which uses either PyQt5, PyQt6 or PySide. This can be installed with
 
 ```
 sudo apt-get install python-pyqtgraph

--- a/doc/installation-macos.md
+++ b/doc/installation-macos.md
@@ -127,9 +127,9 @@ pip install python-osc      # for Python >= 3.5
 pip install python-rtmidi   # for Python >= 3.5
 ```
 
-The graphical user interfaces of `plotsignal` and `plotcontrol` are implemented with pyqtgraph, which uses either PyQt4, PyQt5 or PySide.
+The graphical user interfaces of `plotsignal`, `plotcontrol`, `plotspectral` and `plottrigger` are implemented with pyqtgraph, which uses either PyQt5, PyQt6 or PySide.
 
-When using Anaconda and Python2 or Python3, the bindings between Python and Qt can be installed as follows:
+When using Anaconda, the bindings between Python and Qt can be installed as follows:
 
 ```
 conda install pyqt

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -19,7 +19,7 @@ conda install -y redis-py
 conda install -y numpy
 conda install -y scipy
 conda install -y pyqt
-conda install -y pyqtgraph==0.12
+conda install -y pyqtgraph
 conda install -y python-levenshtein
 conda install -y portaudio
 conda install -y pyaudio

--- a/module/inputcontrol/inputcontrol.py
+++ b/module/inputcontrol/inputcontrol.py
@@ -175,7 +175,7 @@ class Window(QWidget):
                 s.type = item[1]
                 s.setMinimum(0)
                 s.setMaximum(127)  # default is 100
-                s.setValue(val)
+                s.setValue(int(val))
                 s.setStyleSheet('background-color: rgb(64,64,64);')
                 s.valueChanged.connect(self.changevalue)
                 l = QtWidgets.QLabel(s.name)

--- a/module/plotcontrol/plotcontrol.py
+++ b/module/plotcontrol/plotcontrol.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyqtgraph.Qt import QtGui, QtCore
+from PyQt5 import QtCore, QtGui, QtWidgets
 import numpy as np
 import os
 import pyqtgraph as pg
@@ -90,7 +90,7 @@ def _start():
             counter += 1
 
     # start the graphical user interface
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     app.setWindowIcon(QtGui.QIcon(os.path.join(path, '../../doc/figures/logo-128.ico')))
     app.aboutToQuit.connect(_stop)
     signal.signal(signal.SIGINT, _stop)
@@ -98,9 +98,11 @@ def _start():
     # deal with uncaught exceptions
     sys.excepthook = _exception_hook
 
-    win = pg.GraphicsWindow(title=patch.getstring('display', 'title', default='EEGsynth plotcontrol'))
+    win = QtWidgets.QMainWindow()
     win.setWindowTitle(patch.getstring('display', 'title', default='EEGsynth plotcontrol'))
     win.setGeometry(winx, winy, winwidth, winheight)
+    layout = pg.GraphicsLayoutWidget()
+    win.setCentralWidget(layout)
 
     # Enable antialiasing for prettier plots
     pg.setConfigOptions(antialias=True)
@@ -112,8 +114,8 @@ def _start():
 
     # Create panels for each channel
     for iplot, name in enumerate(input_name):
-
-        inputplot.append(win.addPlot(title="%s" % name))
+        
+        inputplot.append(layout.addPlot(title="%s" % name))
         inputplot[iplot].setLabel('bottom', text = 'Time (s)')
         inputplot[iplot].showGrid(x=False, y=True, alpha=None)
 
@@ -128,8 +130,9 @@ def _start():
         linecolor = patch.getstring('linecolor', name, multiple=True, default='w,'*len(variable))
         for icurve in range(len(variable)):
             inputcurve.append(inputplot[iplot].plot(pen=linecolor[icurve]))
+        layout.nextRow()
 
-        win.nextRow()
+    win.show()
 
     # Set timer for update
     timer = QtCore.QTimer()
@@ -177,13 +180,13 @@ def _loop_once():
 def _loop_forever():
     '''Run the main loop forever
     '''
-    QtGui.QApplication.instance().exec_()
+    QtWidgets.QApplication.instance().exec_()
 
 
 def _stop(*args):
     '''Stop and clean up on SystemExit, KeyboardInterrupt, RuntimeError
     '''
-    QtGui.QApplication.quit()
+    QtWidgets.QApplication.quit()
 
 
 def _exception_hook(type, value, tb):

--- a/module/plotsignal/plotsignal.py
+++ b/module/plotsignal/plotsignal.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyqtgraph.Qt import QtGui, QtCore
+from PyQt5 import QtCore, QtGui, QtWidgets
 import numpy as np
 import os
 import pyqtgraph as pg
@@ -140,7 +140,7 @@ def _start():
             endsample = hdr_input.nSamples - 1
 
     # start the graphical user interface
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     app.setWindowIcon(QtGui.QIcon(os.path.join(path, '../../doc/figures/logo-128.ico')))
     app.aboutToQuit.connect(_stop)
     signal.signal(signal.SIGINT, _stop)
@@ -148,9 +148,11 @@ def _start():
     # deal with uncaught exceptions
     sys.excepthook = _exception_hook
 
-    win = pg.GraphicsWindow(title=patch.getstring('display', 'title', default='EEGsynth plotsignal'))
+    win = QtWidgets.QMainWindow()
     win.setWindowTitle(patch.getstring('display', 'title', default='EEGsynth plotsignal'))
     win.setGeometry(winx, winy, winwidth, winheight)
+    layout = pg.GraphicsLayoutWidget()
+    win.setCentralWidget(layout)
 
     # Enable antialiasing for prettier plots
     pg.setConfigOptions(antialias=True)
@@ -163,11 +165,13 @@ def _start():
     # Create panels for each channel
     for plotnr, channr in enumerate(channels):
 
-        timeplot.append(win.addPlot(title="%s%s" % ('Channel ', channr)))
+        timeplot.append(layout.addPlot(title="%s%s" % ('Channel ', channr)))
         timeplot[plotnr].setLabel('left', text='Amplitude')
         timeplot[plotnr].setLabel('bottom', text='Time (s)')
         curve.append(timeplot[plotnr].plot(pen='w'))
-        win.nextRow()
+        layout.nextRow()
+
+    win.show()
 
     # Set timer for update
     timer = QtCore.QTimer()
@@ -269,13 +273,13 @@ def _loop_once():
 def _loop_forever():
     '''Run the main loop forever
     '''
-    QtGui.QApplication.instance().exec_()
+    QtWidgets.QApplication.instance().exec_()
 
 
 def _stop(*args):
     '''Stop and clean up on SystemExit, KeyboardInterrupt, RuntimeError
     '''
-    QtGui.QApplication.quit()
+    QtWidgets.QApplication.quit()
 
 
 def _exception_hook(type, value, tb):

--- a/module/plotspectral/plotspectral.py
+++ b/module/plotspectral/plotspectral.py
@@ -20,7 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyqtgraph.Qt import QtGui, QtCore
+from PyQt5 import QtCore, QtGui, QtWidgets
 import numpy as np
 import os
 import pyqtgraph as pg
@@ -164,7 +164,7 @@ def _start():
             endsample = hdr_input.nSamples - 1
 
     # start the graphical user interface
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     app.setWindowIcon(QtGui.QIcon(os.path.join(path, '../../doc/figures/logo-128.ico')))
     app.aboutToQuit.connect(_stop)
     signal.signal(signal.SIGINT, _stop)
@@ -172,10 +172,12 @@ def _start():
     # deal with uncaught exceptions
     sys.excepthook = _exception_hook
 
-    win = pg.GraphicsWindow(title=patch.getstring('display', 'title', default='EEGsynth plotspectral'))
+    win = QtWidgets.QMainWindow()
     win.setWindowTitle(patch.getstring('display', 'title', default='EEGsynth plotspectral'))
     win.setGeometry(winx, winy, winwidth, winheight)
-
+    layout = pg.GraphicsLayoutWidget()
+    win.setCentralWidget(layout)
+    
     # initialize graphical elements
     text_redleft_curr   = pg.TextItem("", anchor=( 1,  0), color='r')
     text_redright_curr  = pg.TextItem("", anchor=( 0,  0), color='r')
@@ -212,7 +214,7 @@ def _start():
     # Create panels for each channel
     for plotnr, channr in enumerate(channels):
 
-        plot = win.addPlot(title="%s%s" % ('Spectrum channel ', channr))
+        plot = layout.addPlot(title="%s%s" % ('Spectrum channel ', channr))
         # speeds up the initial axis scaling set the range to something different than [0, 0]
         plot.setXRange(0,1)
         plot.setYRange(0,1)
@@ -232,7 +234,7 @@ def _start():
         blueleft_curr.append(freqplot_curr[plotnr].plot(pen='b'))
         blueright_curr.append(freqplot_curr[plotnr].plot(pen='b'))
 
-        plot = win.addPlot(title="%s%s%s%s%s" % ('Averaged spectrum channel ', channr, ' (', historysize, 's)'))
+        plot = layout.addPlot(title="%s%s%s%s%s" % ('Averaged spectrum channel ', channr, ' (', historysize, 's)'))
         # speeds up the initial axis scaling set the range to something different than [0, 0]
         plot.setXRange(0,1)
         plot.setYRange(0,1)
@@ -252,7 +254,6 @@ def _start():
         redright_hist.append(freqplot_hist[plotnr].plot(pen='r'))
         blueleft_hist.append(freqplot_hist[plotnr].plot(pen='b'))
         blueright_hist.append(freqplot_hist[plotnr].plot(pen='b'))
-        win.nextRow()
 
         # initialize as lists
         specmin_curr.append(None)
@@ -261,6 +262,10 @@ def _start():
         specmax_hist.append(None)
         fft_curr.append(None)
         fft_hist.append(None)
+
+        layout.nextRow()
+
+    win.show()
 
     # print frequency at lines
     freqplot_curr[0].addItem(text_redleft_curr)
@@ -454,13 +459,13 @@ def _loop_once():
 def _loop_forever():
     '''Run the main loop forever
     '''
-    QtGui.QApplication.instance().exec_()
+    QtWidgets.QApplication.instance().exec_()
 
 
 def _stop(*args):
     '''Stop and clean up on SystemExit, KeyboardInterrupt, RuntimeError
     '''
-    QtGui.QApplication.quit()
+    QtWidgets.QApplication.quit()
 
 
 def _exception_hook(type, value, tb):

--- a/module/plottrigger/plottrigger.py
+++ b/module/plottrigger/plottrigger.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from pyqtgraph.Qt import QtGui, QtCore
+from PyQt5 import QtCore, QtGui, QtWidgets
 import numpy as np
 import os
 import pyqtgraph as pg
@@ -135,7 +135,7 @@ def _start():
         thread.start()
 
     # start the graphical user interface
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     app.setWindowIcon(QtGui.QIcon(os.path.join(path, '../../doc/figures/logo-128.ico')))
     app.aboutToQuit.connect(_stop)
     signal.signal(signal.SIGINT, _stop)
@@ -143,18 +143,22 @@ def _start():
     # deal with uncaught exceptions
     sys.excepthook = _exception_hook
 
-    win = pg.GraphicsWindow(title=patch.getstring('display', 'title', default='EEGsynth plottrigger'))
+    win = QtWidgets.QMainWindow()
     win.setWindowTitle(patch.getstring('display', 'title', default='EEGsynth plottrigger'))
     win.setGeometry(winx, winy, winwidth, winheight)
+    layout = pg.GraphicsLayoutWidget()
+    win.setCentralWidget(layout)
 
     # Enable antialiasing for prettier plots
     pg.setConfigOptions(antialias=True)
 
-    plot = win.addPlot()
+    plot = layout.addPlot()
     plot.setLabel('left', text='Channel')
     plot.setLabel('bottom', text='Time (s)')
     plot.setXRange(-window, 0)
     plot.setYRange(0.5, len(trigger)+0.5)
+    
+    win.show()
 
     # Set timer for update
     timer = QtCore.QTimer()
@@ -206,7 +210,7 @@ def _loop_once():
 def _loop_forever():
     '''Run the main loop forever
     '''
-    QtGui.QApplication.instance().exec_()
+    QtWidgets.QApplication.instance().exec_()
 
 
 def _stop(*args):
@@ -219,7 +223,7 @@ def _stop(*args):
     patch.publish('PLOTTRIGGER_UNBLOCK', 1)
     for thread in trigger:
         thread.join()
-    QtGui.QApplication.quit()
+    QtWidgets.QApplication.quit()
 
 
 def _exception_hook(type, value, tb):

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setuptools.setup(
         "pyaudio",
         "pylsl",
         "PyQt5",
-        "pyqtgraph==0.12",
+        "pyqtgraph",
         "pyserial",
         "pyzmq",
         "redis",
@@ -91,7 +91,7 @@ setuptools.setup(
         "termcolor",
         "wiringpi; platform_machine == 'armv7l'"
     ],
-    python_requires=">=2.7",
+    python_requires=">=3.8",
     extras_require={
         ":python_version<'3.5'": ["pyOSC"],
         ":python_version>='3.5'": ["python-rtmidi"],


### PR DESCRIPTION
Code changes include not importing Qt objects any more through pyqtgraph, making an explicit pg.GraphicsLayoutWidget as the central widget of the QMainWindow, adding the plots to that layout, and some related changes. The overall logic is still the same.
